### PR TITLE
Travis CI: Update environment, add Arm64 job, refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: c
-os:
-  - linux
-env:
-  - TR_ARCH=local
+dist: bionic
+arch:
+ - amd64
+ - arm64
+ 
+env: TR_ARCH=local
+
+install:
+ - ./autogen.sh
+ - ./configure
+
 script:
-  - ./autogen.sh
-  - ./configure
-  - make all
-  - python3 ./travis/nasm-t.py run
+ - make all
+ - python3 ./travis/nasm-t.py run


### PR DESCRIPTION
 - Updates build environment to Ubuntu 18.04 Bionic
 - Adds Arm64 job
 - Small cosmetic refactor

Travis is currently stuck on [this error](https://travis-ci.com/github/EwoutH/nasm/jobs/356840138#L769) in the `make all` step. This bug is already present in the master branch and is not changed by this PR.

```
output/outlib.c:197:6: error: no previous prototype for ‘ol_add_sym_to’ [-Werror=missing-prototypes]
 void ol_add_sym_to(struct ol_symlist *syml, struct ol_symhead *head,
      ^~~~~~~~~~~~~
cc1: some warnings being treated as errors
Makefile:85: recipe for target 'output/outlib.o' failed
make[1]: *** [output/outlib.o] Error 1
make[1]: Leaving directory '/home/travis/build/EwoutH/nasm'
Makefile:156: recipe for target 'all' failed
make: *** [all] Error 2
```