### PR TITLE
Fix for Bug 3392609 - Buffer overflow

### DIFF
--- a/disasm/ndisasm.c
+++ b/disasm/ndisasm.c
@@ -297,7 +297,7 @@ int main(int argc, char **argv)
     p = q = buffer;
     nextsync = next_sync(offset, &synclen);
     do {
-        uint32_t to_read = buffer + sizeof(buffer) - p;
+        int32_t to_read = buffer + sizeof(buffer) - p;
 	if ((nextsync || synclen) &&
 	    to_read > nextsync - offset - (p - q))
             to_read = nextsync - offset - (p - q);


### PR DESCRIPTION
Hi,

I am proposing a change in `ndisasm.c` file in order to fix the buffer overflow reported in https://bugzilla.nasm.us/show_bug.cgi?id=3392609. I have verified that the bug is still present in the latest version of ndisasm.

Changing the type of `to_read` from `uint32_t` to `int32_t` makes it aware of negative numbers and should fix the reported buffer overflow in ndisasm. I have not seen that this change breaks legitimate use cases, the fix was tested on Ubuntu 20.04 and 20.10.

There are also other ways to fix this issue, this one seemed the quickest and easiest.

Let me know what you think.