### PR TITLE
Add DW_AT_comp_dir to elf files.

### DIFF
--- a/output/outelf.c
+++ b/output/outelf.c
@@ -84,6 +84,7 @@ static struct hash_table section_by_name;
 static struct elf_symbol *fwds;
 
 static char elf_module[FILENAME_MAX];
+static char elf_dir[FILENAME_MAX];
 
 extern const struct ofmt of_elf32;
 extern const struct ofmt of_elf64;
@@ -552,8 +553,10 @@ static void elf_init(void)
         ".shstrtab", ".strtab", ".symtab", ".symtab_shndx", NULL
     };
     const char * const *p;
+    const char * cur_path = nasm_realpath(inname);
 
     strlcpy(elf_module, inname, sizeof(elf_module));
+    strlcpy(elf_dir, nasm_dirname(cur_path), sizeof(elf_dir));
     sects = NULL;
     nsects = sectlen = 0;
     syms = saa_init((int32_t)sizeof(struct elf_symbol));
@@ -3307,7 +3310,8 @@ static void dwarf_generate(void)
         saa_write32(pinforel, (dwarf_linesym << 8) +  R_386_32); /* reloc to line */
         saa_write32(pinforel, 0);
         saa_write32(pinfo,0);       /* DW_AT_stmt_list */
-        saa_wbytes(pinfo, elf_module, strlen(elf_module)+1);
+        saa_wbytes(pinfo, elf_module, strlen(elf_module)+1); /* DW_AT_name */
+        saa_wbytes(pinfo, elf_dir, strlen(elf_dir)+1); /* DW_AT_comp_dir */
         saa_wbytes(pinfo, nasm_signature(), nasm_signature_len()+1);
         saa_write16(pinfo,DW_LANG_Mips_Assembler);
         saa_write8(pinfo,2);        /* abbrviation number LEB128u */
@@ -3346,7 +3350,8 @@ static void dwarf_generate(void)
         saa_write32(pinforel, (dwarf_linesym << 8) + R_X86_64_32); /* reloc to line */
         saa_write32(pinforel, 0);
         saa_write32(pinfo,0);			/* DW_AT_stmt_list */
-        saa_wbytes(pinfo, elf_module, strlen(elf_module)+1);
+        saa_wbytes(pinfo, elf_module, strlen(elf_module)+1); /* DW_AT_name */
+        saa_wbytes(pinfo, elf_dir, strlen(elf_dir)+1); /* DW_AT_comp_dir */
         saa_wbytes(pinfo, nasm_signature(), nasm_signature_len()+1);
         saa_write16(pinfo,DW_LANG_Mips_Assembler);
         saa_write8(pinfo,2);			/* abbrviation number LEB128u */
@@ -3386,7 +3391,8 @@ static void dwarf_generate(void)
         saa_write64(pinforel, (dwarf_linesym << 32) +  R_X86_64_32); /* reloc to line */
         saa_write64(pinforel, 0);
         saa_write32(pinfo,0);			/* DW_AT_stmt_list */
-        saa_wbytes(pinfo, elf_module, strlen(elf_module)+1);
+        saa_wbytes(pinfo, elf_module, strlen(elf_module)+1); /* DW_AT_name */
+        saa_wbytes(pinfo, elf_dir, strlen(elf_dir)+1); /* DW_AT_comp_dir */
         saa_wbytes(pinfo, nasm_signature(), nasm_signature_len()+1);
         saa_write16(pinfo,DW_LANG_Mips_Assembler);
         saa_write8(pinfo,2);			/* abbrviation number LEB128u */
@@ -3423,6 +3429,8 @@ static void dwarf_generate(void)
     saa_write8(pabbrev,DW_AT_stmt_list);
     saa_write8(pabbrev,DW_FORM_data4);
     saa_write8(pabbrev,DW_AT_name);
+    saa_write8(pabbrev,DW_FORM_string);
+    saa_write8(pabbrev,DW_AT_comp_dir);
     saa_write8(pabbrev,DW_FORM_string);
     saa_write8(pabbrev,DW_AT_producer);
     saa_write8(pabbrev,DW_FORM_string);


### PR DESCRIPTION
Hi!

I am proposing this patch to add compilation directory debug information in ELF files. This helps locate the source code file during debugging sessions if they are not in one of the default directories.

I did not add any tests for this (I tested it manually), but would appreciate any suggestions for testing the feature.