### PR TITLE
preproc: don't unmacro if macro cannot be found.

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -4330,6 +4330,11 @@ issue_error:
             goto done;
         }
         mmac_p = (MMacro **) hash_findi(&mmacros, spec.name, NULL);
+        if (mmac_p == NULL) {
+          // If the macro cannot be found, there's nothing to do.
+          free_tlist(spec.dlist);
+          break;
+        }
 
         /* Check the macro to be undefined is not being expanded */
         list_for_each(l, istk->expansion) {


### PR DESCRIPTION
This commit adds a check to see if the macro that we want to unmacro exists.
A previous commit, introduced a check to see if the unmacro was undefining a macro being expanded, but that same check included a null pointer dereference if the macro to undefine did not exist.

The following code reproduced the issue:

```asm
%macro baz 0
  %unmacro F 0
%endmacro
baz
```

Compile with:
```shell
$ nasm -f elf64 -g -FDWARF -o tmp.o -werror file.asm
```

Fixes bug 3392761