### PR TITLE
version.pl: Don't use chomp to support Windows Perl

### DIFF
--- a/version.pl
+++ b/version.pl
@@ -68,7 +68,7 @@
 ($what) = @ARGV;
 
 $line = <STDIN>;
-chomp $line;
+$line =~ s/\x0D?\x0A?$//; #chomp $line;
 
 undef $maj;
 undef $min;

--- a/version.pl
+++ b/version.pl
@@ -68,7 +68,7 @@
 ($what) = @ARGV;
 
 $line = <STDIN>;
-$line =~ s/\x0D?\x0A?$//; #chomp $line;
+$line =~ s/\R\z//; #chomp $line;
 
 undef $maj;
 undef $min;

--- a/version.pl
+++ b/version.pl
@@ -68,7 +68,7 @@
 ($what) = @ARGV;
 
 $line = <STDIN>;
-$line =~ s/\R\z//; #chomp $line;
+$line =~ s/\x0D?\x0A?$//; #chomp $line;
 
 undef $maj;
 undef $min;


### PR DESCRIPTION
```sh
$ perl --version

This is perl 5, version 32, subversion 1 (v5.32.1) built for x86_64-msys-thread-multi
...
```
Windows uses CR LF for line break characters. I think that you shouldn't use Perl `chomp` for Windows.