### PR TITLE
Emit the LC_BUILD_VERSION load command when creating a mach object.

### DIFF
--- a/asm/nasm.c
+++ b/asm/nasm.c
@@ -167,6 +167,10 @@ static char *quote_for_pmake(const char *str);
 static char *quote_for_wmake(const char *str);
 static char *(*quote_for_make)(const char *) = quote_for_pmake;
 
+#if defined(OF_MACHO) || defined(OF_MACHO64)
+extern bool macho_set_min_os(const char *str);
+#endif
+
 /*
  * Execution limits that can be set via a command-line option or %pragma
  */
@@ -1338,6 +1342,23 @@ static bool process_arg(char *p, char *q, int pass)
                 case OPT_REPRODUCIBLE:
                     reproducible = true;
                     break;
+                case OPT_MACHO_MIN_OS:
+                    if (pass == 2) {
+                        if (strstr(ofmt->shortname, "macho") != ofmt->shortname) {
+                            nasm_error(
+                                ERR_WARNING | WARN_OTHER | ERR_USAGE,
+                                "macho-min-os is only valid for macho format, current: %s",
+                                ofmt->shortname);
+                            break;
+                        }
+#if defined(OF_MACHO) || defined(OF_MACHO64)
+                        if (!macho_set_min_os(param)) {
+                            nasm_fatalf(ERR_USAGE, "failed to set minimum os for mach-o '%s'",
+                                        param);
+                        }
+#endif
+                    }
+                    break;
                 case OPT_HELP:
                     help(stdout);
                     exit(0);
@@ -2296,6 +2317,8 @@ static void help(FILE *out)
         "   --lpostfix str append the given string to local symbols\n"
         "\n"
         "   --reproducible attempt to produce run-to-run identical output\n"
+        "\n"
+        "   --macho-min-os minos minimum os version for mach-o format(example: macos-11.0)\n"
         "\n"
         "    -w+x          enable warning x (also -Wx)\n"
         "    -w-x          disable warning x (also -Wno-x)\n"

--- a/output/macho.h
+++ b/output/macho.h
@@ -60,6 +60,7 @@
 #define LC_SEGMENT			0x1
 #define LC_SEGMENT_64			0x19
 #define LC_SYMTAB			0x2
+#define LC_BUILD_VERSION		0x32
 
 /* Symbol type bits */
 #define N_STAB				0xe0
@@ -143,6 +144,20 @@
 /* Relocation info */
 #define R_ABS		0
 #define R_SCATTERED	0x80000000
+
+/* Known values for the platform field in LC_BUILD_VERSION */
+#define PLATFORM_MACOS				1
+#define PLATFORM_IOS				2
+#define PLATFORM_TVOS				3
+#define PLATFORM_WATCHOS			4
+#define PLATFORM_BRIDGEOS			5
+#define PLATFORM_MACCATALYST		6
+#define PLATFORM_IOSSIMULATOR		7
+#define PLATFORM_TVOSSIMULATOR		8
+#define PLATFORM_WATCHOSSIMULATOR	9
+#define PLATFORM_DRIVERKIT			10
+
+#define PLATFORM_INVALID			0
 
 /* VM permission constants */
 #define	VM_PROT_NONE			0x00


### PR DESCRIPTION
LC_BUILD_VERSION contains the min OS version on which this binary
was built to run for its platform in mach object. It is required for
targets like iOS Catalyst.

Also, emit the __LLVM segment, __asm section to tell the Apple
toolchain that this object is from assembler and has no bitcode.
This trick is used in Kotlin/Native, Rust, Flutter, Golang and yasm.