### PR TITLE
preproc: fix misparsing of << as right shift

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -1613,7 +1613,7 @@ static Token *tokenize(const char *line)
 	    case '<':
 		if (*p == '<') {
 		    p++;
-                    type = TOKEN_SHR;
+                    type = TOKEN_SHL;
 		    if (*p == '<')
 			p++;
 		} else if (*p == '=') {


### PR DESCRIPTION
Regression in commit 20e0d616dc954d567c8bf2c7e11cc5d6c10ac544.

Independently discovered and fixed by C. Masloch at https://bugzilla.nasm.us/show_bug.cgi?id=3392747 (as I learned once I had finished my own investigation and rechecked the Bugzilla with specific keywords in mind), but the patch never made it to the Git repository.

This seems like an obvious and clearly benevolent patch, so I’d love to see this merged soon.

For what it’s worth, like C. Masloch, I have also not spotted any other yet-unfixed problems in that commit, but I’m not at all versed in NASM internals. (I did notice that `LPAR` and `RPAR` had swapped names, but that’s already fixed in `master`.)

Fixes the samples in https://bugzilla.nasm.us/show_bug.cgi?id=3392747.
Fixes libass build as reported in https://github.com/libass/libass/issues/552.