### PR TITLE
Fix Wbitwise-instead-of-logical warning

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -2693,7 +2693,7 @@ iftype:
         t = tline = expand_smacro(tline);
 
         while (tok_white(t) ||
-               (needtype == TOKEN_NUM && (tok_is(t, '-') | tok_is(t, '+'))))
+               (needtype == TOKEN_NUM && (tok_is(t, '-') || tok_is(t, '+'))))
             t = t->next;
 
         j = tok_is(t, needtype);


### PR DESCRIPTION
`a || b` only evaluates b if a is false. `a | b` always evaluates
both a and b. If a and b are of type bool, || is usually what you
want, so clang now warns on `|` where both arguments are of type bool.

This warning fires once in nasm. It looks like `|` is an (inconsequential)
typo of `||`, so use that instead.

No intended behavior change.