### PR TITLE
Fix broken RDF2 output

### DIFF
--- a/asm/segalloc.c
+++ b/asm/segalloc.c
@@ -40,7 +40,7 @@
 #include "nasmlib.h"
 #include "insns.h"
 
-static int32_t next_seg  = 2;
+static int32_t next_seg  = 0;
 
 int32_t seg_alloc(void)
 {


### PR DESCRIPTION
Cause "rdf segment numbers not allocated as expected (2,4,6)"

See outrdf2.c:

    segtext = seg_alloc();
    segdata = seg_alloc();
    segbss = seg_alloc();
    if (segtext != 0 || segdata != 2 || segbss != 4)
        nasm_panic("rdf segment numbers not allocated as expected (%d,%d,%d)",
                   segtext, segdata, segbss);