### PR TITLE
Fix wrong size calculation for "Dx ?" larger than DB

### DIFF
--- a/asm/assemble.c
+++ b/asm/assemble.c
@@ -1111,7 +1111,7 @@ static int64_t len_extops(const extop *e)
             break;
 
         case EOT_DB_RESERVE:
-            isize += e->dup;
+            isize += e->dup * e->elem;
             break;
         }
 


### PR DESCRIPTION
The size calculation done in `len_extops()` (called by `insn_size()`) for `EOT_DB_RESERVE` (i.e. uninitialized storage `?` token) does not take into account the element size (`e->elem`), thus calculating a wrong size for any Dx larger than DB (DW, DQ, etc).

The bug is silent, but it makes NASM error out if a "Dx ?" (larger than DB) is followed by any label because the label offset gets mismatched in the final code generation stage:

    $ cat test.asm
    [section .bss]
    DW ?
    x:

    $ nasm test.asm
    test.asm:3: error: label `x' changed during code generation [-w+error=label-redef-late]

See also [this StackOverflow question](https://stackoverflow.com/q/70012188/3889449) complaining about the problem.