### PR TITLE
Remove the operator with side effect from a part of while loop expression

### DIFF
--- a/asm/assemble.c
+++ b/asm/assemble.c
@@ -643,8 +643,10 @@ static void out_eops(struct out_data *data, const extop *e)
             break;
 
         case EOT_EXTOP:
-            while (dup--)
+            while (dup) {
                 out_eops(data, e->val.subexpr);
+								dup--;
+						}
             break;
 
         case EOT_DB_NUMBER:


### PR DESCRIPTION
Reasoning: you do not need to think about differences between "pre-" and "post-" decrement forms while code reading.