### PR TITLE
Fixed optional comma separator in %strcat

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -4709,15 +4709,12 @@ issue_error:
         list_for_each(t, tline) {
             switch (t->type) {
             case TOKEN_WHITESPACE:
+            case TOKEN_COMMA:
                 break;
             case TOKEN_STR:
 		unquote_token(t);
                 len += t->len;
                 break;
-            case TOKEN_OTHER:
-                if (tok_is(t, ',')) /* permit comma separators */
-                    break;
-                /* else fall through */
             default:
                 nasm_nonfatal("non-string passed to `%s': %s", dname,
 			      tok_text(t));


### PR DESCRIPTION
Regression in commit 20e0d616dc954d567c8bf2c7e11cc5d6c10ac544.

The comma now arrives as TOKEN_COMMA rather than TOKEN_OTHER - so the optional (as mentioned in the docs) comma separators in %strcat are not allowed.