### PR TITLE
fix/doc: correct SourceCodePro and SourceSansPro fonts' names

### DIFF
--- a/doc/psfonts.ph
+++ b/doc/psfonts.ph
@@ -6,20 +6,20 @@
 # Font substitution lists, in order of preference
 my @TText = ('SourceSansPro-Bold', 'ClearSans-Bold', 'LiberationSans-Bold',
 	     'Arial-Bold', 'Helvetica-Bold');
-my @TItal = ('SourceSansPro-BoldIt', 'ClearSans-BoldItalic', 'LiberationSans-BoldItalic',
+my @TItal = ('SourceSansPro-BoldItalic', 'ClearSans-BoldItalic', 'LiberationSans-BoldItalic',
 	     'Arial-BoldItalic', 'Helvetica-BoldItalic');
 my @TCode = ('SourceCodePro-Bold', 'LiberationMono-Bold', 'Courier-Bold');
-my @HText = ('SourceSansPro-Semibold', 'ClearSans-Bold', 'Arial-Bold', 'Helvetica-Bold');
-my @HItal = ('SourceSansPro-SemiboldIt', 'ClearSans-BoldItalic',
+my @HText = ('SourceSansPro-SemiBold', 'ClearSans-Bold', 'Arial-Bold', 'Helvetica-Bold');
+my @HItal = ('SourceSansPro-SemiBoldItalic', 'ClearSans-BoldItalic',
 	     'Arial-BoldItalic', 'Helvetica-BoldItalic');
-my @HCode = ('SourceCodePro-Semibold', 'LiberationMono-Bold', 'Courier-Bold');
+my @HCode = ('SourceCodePro-SemiBold', 'LiberationMono-Bold', 'Courier-Bold');
 my @BText = ('SourceSansPro-Regular', 'ClearSans', 'LiberationSans', 'Arial', 'Helvetica');
-my @BItal = ('SourceSansPro-It', 'ClearSans-Italic', 'LiberationSans-Italic',
+my @BItal = ('SourceSansPro-Italic', 'ClearSans-Italic', 'LiberationSans-Italic',
 	     'Arial-Italic', 'Helvetica-Italic');
 my @BCode = ('SourceCodePro-Regular', 'LiberationMono', 'Courier');
-my @QText = ('SourceSansPro-It', 'ClearSans-Italic', 'LiberationSans-Italic',
+my @QText = ('SourceSansPro-Italic', 'ClearSans-Italic', 'LiberationSans-Italic',
 	     'Arial-Italic', 'Helvetica-Italic');
-my @QBold = ('SourceSansPro-BoldIt', 'ClearSans-BoldItalic', 'LiberationSans-BoldItalic', 'Arial-Bold', 'Helvetica-BoldItalic');
+my @QBold = ('SourceSansPro-BoldItalic', 'ClearSans-BoldItalic', 'LiberationSans-BoldItalic', 'Arial-Bold', 'Helvetica-BoldItalic');
 my @QCode = ('SourceCodePro-Regular', 'LiberationMono', 'Courier');
 my @XCode = ('SourceCodePro-Regular', 'LiberationMono', 'Courier');
 


### PR DESCRIPTION
Some fonts' names defined in the psfonts.ph are inconsistant with the fonts in the SourceSansPro and SourceCodePro fonts families, which would cause an error when using `make everything`.
The fonts families downloaded from fonts.google.com, list below:

```
-rw-rw-r-- 1 ubuntu ubuntu 4.6K Sep 20  2012 OFL.txt
-rw-rw-r-- 1 ubuntu ubuntu 2.7K Feb 15 01:31 README.txt
-rw-rw-r-- 1 ubuntu ubuntu 159K Sep 20  2012 SourceCodePro-Italic-VariableFont_wght.ttf
-rw-rw-r-- 1 ubuntu ubuntu 192K Sep 20  2012 SourceCodePro-VariableFont_wght.ttf
-rw-r--r-- 1 ubuntu ubuntu 1.1M Feb 15 17:31 Source_Code_Pro.zip
-rw-rw-r-- 1 ubuntu ubuntu 107K Jul 31  2012 SourceSansPro-BlackItalic.ttf
-rw-rw-r-- 1 ubuntu ubuntu 243K Jul 31  2012 SourceSansPro-Black.ttf
-rw-rw-r-- 1 ubuntu ubuntu 107K Jul 31  2012 SourceSansPro-BoldItalic.ttf
-rw-rw-r-- 1 ubuntu ubuntu 242K Jul 31  2012 SourceSansPro-Bold.ttf
-rw-rw-r-- 1 ubuntu ubuntu 108K Jul 31  2012 SourceSansPro-ExtraLightItalic.ttf
-rw-rw-r-- 1 ubuntu ubuntu 242K Jul 31  2012 SourceSansPro-ExtraLight.ttf
-rw-rw-r-- 1 ubuntu ubuntu 108K Jul 31  2012 SourceSansPro-Italic.ttf
-rw-rw-r-- 1 ubuntu ubuntu 108K Jul 31  2012 SourceSansPro-LightItalic.ttf
-rw-rw-r-- 1 ubuntu ubuntu 242K Jul 31  2012 SourceSansPro-Light.ttf
-rw-rw-r-- 1 ubuntu ubuntu 243K Jul 31  2012 SourceSansPro-Regular.ttf
-rw-rw-r-- 1 ubuntu ubuntu 107K Jul 31  2012 SourceSansPro-SemiBoldItalic.ttf
-rw-rw-r-- 1 ubuntu ubuntu 243K Jul 31  2012 SourceSansPro-SemiBold.ttf
-rw-r--r-- 1 ubuntu ubuntu 964K Feb 15 17:14 Source_Sans_Pro.zip
drwxrwxr-x 2 ubuntu ubuntu 4.0K Feb 15 17:32 static
```

Signed-off-by: chengzhycn <chengzhycn@gmail.com>