### PR TITLE
remove unused coff_alignment()

### DIFF
--- a/output/outcoff.c
+++ b/output/outcoff.c
@@ -325,15 +325,6 @@ static inline uint32_t coff_sectalign_flags(unsigned int align)
 }
 
 /*
- * Get the alignment value from a flags field.
- * Returns 0 if no alignment defined.
- */
-static inline unsigned int coff_alignment(uint32_t flags)
-{
-    return (1U << ((flags & IMAGE_SCN_ALIGN_MASK) >> 20)) >> 1;
-}
-
-/*
  * Get the default section flags (based on section name)
  */
 static uint32_t coff_section_flags(char *name, uint32_t flags)


### PR DESCRIPTION
Usage was removed in b6ba0a23f975844f412c2b1afc864413719b6d48
Fixes:
output/outcoff.c:302:28: warning: unused function 'coff_alignment' [-Wunused-function]
static inline unsigned int coff_alignment(uint32_t flags)
                           ^
