### PR TITLE
Fix warning on ; outside of function

### DIFF
--- a/nasmlib/crc32.c
+++ b/nasmlib/crc32.c
@@ -112,4 +112,4 @@ uint32_t crc32b(uint32_t crc, const void *data, size_t len)
     }
 
     return hashval;
-};
+}


### PR DESCRIPTION
Fix "warning ISO C does not allow extra ‘;’ outside of a function" when using gcc v8.5. 
Signed-off-by: Carlos Bilbao <carlos.bilbao@amd.com>