### PR TITLE
fix memory leak in asm/nasm.c

### DIFF
--- a/asm/nasm.c
+++ b/asm/nasm.c
@@ -607,6 +607,7 @@ int main(int argc, char **argv)
     if (!outname && !(operating_mode & OP_PREPROCESS)) {
         outname = filename_set_extension(inname, ofmt->extension);
         if (!strcmp(outname, inname)) {
+            nasm_free((char *)outname);
             outname = "nasm.out";
             nasm_warn(WARN_OTHER, "default output file same as input, using `%s' for output\n", outname);
         }


### PR DESCRIPTION
compile it with asan
```
git clone https://github.com/netwide-assembler/nasm.git
cd nasm
sh autogen.sh;
AFL_USE_ASAN=1 ./configure CC=afl-gcc CXX=afl-g++ LD=afl-gcc--disable-shared;
AFL_USE_ASAN=1 make;
```

run
```
$ ./nasm myinput/test1  
myinput/test1: warning: default output file same as input, using `nasm.out' for output
 [-w+other]
nasm: fatal: unable to open input file `myinput/test1' No such file or directory

=================================================================
==14512==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 14 byte(s) in 1 object(s) allocated from:
    #0 0x7f10ccd7a808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x559a339ff044 in nasm_malloc nasmlib/alloc.c:55

SUMMARY: AddressSanitizer: 14 byte(s) leaked in 1 allocation(s).
```

Analysis : 

When the first argument of nasm is a pathname without '.', forget to free outname before set `outname = "nasm.out";`.