### PR TITLE
omit input filename from COFF output when `--reproducible`

### DIFF
--- a/output/outcoff.c
+++ b/output/outcoff.c
@@ -1275,7 +1275,10 @@ static void coff_write_symbols(void)
      * The `.file' record, and the file name auxiliary record.
      */
     coff_symbol(".file", 0L, 0L, -2, 0, 0x67, 1);
-    strncpy(filename, inname, 18);
+    if (reproducible)
+        memset(filename, 0, 18);
+    else
+        strncpy(filename, inname, 18);
     nasm_write(filename, 18, ofile);
 
     /*


### PR DESCRIPTION
Before this patch, COFF output always contained the first 18 bytes of the
input filename. This breaks reproducibility and may also leak sensitive
data to objects (esp. with input filenames with absolute paths.)

This patch makes this output respect the `--reproducible` option, and omits
the input filename from the COFF output, when set.