### PR TITLE
fix memory leak （Repair cve-2021-33450 cve-2021-33452 ）

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -4854,6 +4854,7 @@ issue_error:
     }
 
 done:
+    free_mmacro_table(&mmacros);
     free_tlist(origline);
     return DIRECTIVE_FOUND;
 }


### PR DESCRIPTION
    case PP_ENDM:
    case PP_ENDMACRO:
        if (!(defining && defining->name)) {
            nasm_nonfatal("`%s': not defining a macro", tok_text(tline));
            goto done;
        }
        mmhead = (MMacro **) hash_findi_add(&mmacros, defining->name);
        defining->next = *mmhead;
        *mmhead = defining;
        defining = NULL;
        break;

The variable: mmacros  has not been released, which will cause a memory leak. Repair cve-2021-33450 cve-2021-33452 synchronously