### PR TITLE
output/outelf: Fix relocation for DW_AT_high_pc

### DIFF
--- a/output/outelf.c
+++ b/output/outelf.c
@@ -3339,8 +3339,8 @@ static void dwarf_generate(void)
         saa_write32(pinfo,0);			/* DW_AT_low_pc */
         saa_write32(pinforel, pinfo->datalen + 4);
         saa_write32(pinforel, ((dwarf_fsect->section + 2) << 8) + R_X86_64_32);
-        saa_write32(pinforel, 0);
-        saa_write32(pinfo,highaddr);		/* DW_AT_high_pc */
+        saa_write32(pinforel, highaddr);
+        saa_write32(pinfo,0);			/* DW_AT_high_pc */
         saa_write32(pinforel, pinfo->datalen + 4);
         saa_write32(pinforel, (dwarf_linesym << 8) + R_X86_64_32); /* reloc to line */
         saa_write32(pinforel, 0);
@@ -3380,8 +3380,8 @@ static void dwarf_generate(void)
         saa_write64(pinfo,0);			/* DW_AT_low_pc */
         saa_write64(pinforel, pinfo->datalen + 4);
         saa_write64(pinforel, ((uint64_t)(dwarf_fsect->section + 2) << 32) +  R_X86_64_64);
-        saa_write64(pinforel, 0);
-        saa_write64(pinfo,highaddr);		/* DW_AT_high_pc */
+        saa_write64(pinforel, highaddr);
+        saa_write64(pinfo,0);			/* DW_AT_high_pc */
         saa_write64(pinforel, pinfo->datalen + 4);
         saa_write64(pinforel, (dwarf_linesym << 32) +  R_X86_64_32); /* reloc to line */
         saa_write64(pinforel, 0);


### PR DESCRIPTION
The information for DW_AT_high_pc was not correctly generated. Instead of having a relocation whose value was `.text + highaddr` we wrote `highaddr` to the output file location and added a relocation for `.text + 0`.

This change writes `0` to the file and creates the correct relocation. The previous behaviour wasn't noticed before because GNU ld had the opposite issue: it added the target contents with the symbol value and the entry addend. These two bugs coexisted in peace until GNU ld fixed their broken interpretation of the spec on https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=17c6c3b99156fe82c1e637e1a5fd9f163ac788c8

This will fix broken debug information for binaries generated with lld and newer ld versions.

`elf32` relocations are left untouched because the current behaviour (emitting RELA relocations) is broken, see: https://github.com/netwide-assembler/nasm/pull/37

More information:
- https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-54839.html#chapter7-2
- https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=bfd/bfd-in2.h;h=4ab7e2d69347fc8d707094c18b29e1b32ecfcd69;hb=HEAD#l2063
    
Fixes: https://bugzilla.nasm.us/show_bug.cgi?id=3392798