### PR TITLE
output/elf: Don't set data symbol type/size in ABS sections

### DIFF
--- a/output/outelf.c
+++ b/output/outelf.c
@@ -2696,7 +2696,11 @@ static void debug_typevalue(int32_t type)
             stype = STT_NOTYPE;
             break;
     }
-    if (stype == STT_OBJECT && lastsym && !lastsym->type) {
+    /* Set type and size info on most recently seen symbol if we haven't set it already.
+       But avoid setting size info on object (data) symbols in absolute sections (which
+       is primarily structs); some environments get confused with non-zero-extent absolute
+       object symbols and end up showing them in backtraces for NULL fn pointer calls. */
+    if (stype == STT_OBJECT && lastsym && !lastsym->type && lastsym->section != XSHN_ABS) {
         lastsym->size = ssize;
         lastsym->type = stype;
     }


### PR DESCRIPTION
I'm dealing with a FreeBSD-derived embedded target that ends up
showing such symbols (which is mainly NASM struct definitions)
in backtraces after calling NULL function pointers, since these
symbols _are_ technically covering bytes around address zero.

Needless to say, this is extremely confusing and generates
nonsensical bug reports. (Essentially, random unrelated crashes
get cross-referenced to a random ASM struct, whatever the linker
picked for address 0).

These symbols are already a bit strange to begin with (they're
purely an artifact of how NASM happens to implement structs),
leaving their sizes at 0 seems reasonable.

Signed-off-by: Fabian Giesen <fabian.giesen@epicgames.com>