### PR TITLE
Store DW_AT_high_pc addend in RELA relocation

### DIFF
--- a/output/outelf.c
+++ b/output/outelf.c
@@ -3339,8 +3339,8 @@ static void dwarf_generate(void)
         saa_write32(pinfo,0);			/* DW_AT_low_pc */
         saa_write32(pinforel, pinfo->datalen + 4);
         saa_write32(pinforel, ((dwarf_fsect->section + 2) << 8) + R_X86_64_32);
-        saa_write32(pinforel, 0);
-        saa_write32(pinfo,highaddr);		/* DW_AT_high_pc */
+        saa_write32(pinforel, highaddr);
+        saa_write32(pinfo, 0);		/* DW_AT_high_pc */
         saa_write32(pinforel, pinfo->datalen + 4);
         saa_write32(pinforel, (dwarf_linesym << 8) + R_X86_64_32); /* reloc to line */
         saa_write32(pinforel, 0);
@@ -3380,8 +3380,8 @@ static void dwarf_generate(void)
         saa_write64(pinfo,0);			/* DW_AT_low_pc */
         saa_write64(pinforel, pinfo->datalen + 4);
         saa_write64(pinforel, ((uint64_t)(dwarf_fsect->section + 2) << 32) +  R_X86_64_64);
-        saa_write64(pinforel, 0);
-        saa_write64(pinfo,highaddr);		/* DW_AT_high_pc */
+        saa_write64(pinforel, highaddr);
+        saa_write64(pinfo, 0);		/* DW_AT_high_pc */
         saa_write64(pinforel, pinfo->datalen + 4);
         saa_write64(pinforel, (dwarf_linesym << 32) +  R_X86_64_32); /* reloc to line */
         saa_write64(pinforel, 0);


### PR DESCRIPTION
x86-64 uses RELA relocation which stores addend in RELA relocation.
Store DW_AT_high_pc addend in RELA relocation instead of at the
relocation offset.  Otherwise, DW_AT_high_pc addend will be ignored
by linker.

This fixes:

https://bugzilla.nasm.us/show_bug.cgi?id=3392798