### PR TITLE
Make istruc "at" support struc local labels

### DIFF
--- a/macros/standard.mac
+++ b/macros/standard.mac
@@ -99,7 +99,13 @@ STD: nasm
 %endmacro
 
 %imacro at 1-2+.nolist
-    times (%1-%$strucname)-($-%$strucstart) db 0
+    %defstr %$member %1
+    %substr %$member1 %$member 1
+    %ifidn %$member1, '.'
+        times (%$strucname%1-%$strucname)-($-%$strucstart) db 0
+    %else
+        times (%1-%$strucname)-($-%$strucstart) db 0
+    %endif
     %2
 %endmacro
 

--- a/test/istruc_local.asm
+++ b/test/istruc_local.asm
@@ -1,0 +1,37 @@
+;Testname=test; Arguments=-fbin -oistruc_local.bin; Files=stdout stderr istruc_local.bin
+
+struc Struc1
+    .dword: resd 1
+    .word: resw 1
+endstruc
+
+struc Struc2
+    .word: resw 1
+    .dword: resd 1
+endstruc
+
+; The following returned error about negative values for TIMES in nasm 2.15.05
+; because local labels seemingly matching Struc1 have been replaced by those in
+; Struc2.
+
+istruc Struc1
+    at .dword, dd 0xffffffff
+    at .word, dw 0x1111
+iend
+
+; The following two just didn't work as istruc was just literally outputting
+; local labels which are unknown after a global label appears.
+
+struc1:
+
+istruc Struc1
+    at .dword, dd 0x78563412
+    at .word, dw 0xbc9a
+iend
+
+struc2:
+
+istruc Struc2
+    at .word, dw 0xbc9a
+    at .dword, dd 0x78563412
+iend


### PR DESCRIPTION
A quote from the first commit:

---

istruc currently does not work very well with passing local labels to
"at" macro, as the labels are inserted literally. E.g. considering the
example from test/struc.asm:

	struc teststruc1
	  .long: resd 1
	  .word: resw 1
	  .byte: resb 1
	  .str:  resb 32
	endstruc
	; ...
	istruc teststruc1
	 at .word, db 5
	iend

if one were to put a global label before istruc to refer to its
instance, the code would fail to compile, due to ".word" being unknown
in that scope. Of course one could then use full form after "at", i.e.
"teststruc1.word", but this seems rather tedious.

This also makes istruc use with local labels fail for anything but the
last declared struc.

The change automatically prepends struc name to the label if the label
given to "at" starts with a dot.

---

The second one adds a test case that also showcases the problem with the current state of `istruc` and `at` macros. I hope I've chosen a sane macro use to implement that dot check.