### PR TITLE
Fixed PDF doc line overflow

### DIFF
--- a/doc/nasmdoc.src
+++ b/doc/nasmdoc.src
@@ -6290,7 +6290,8 @@ It will get linked into the \c{.text} section anyway - see the info on
 \c       ...                                        ; Code linked only if referenced from C
 \c
 \c    section .rdata align=32 comdat=5:FirstFnc
-\c       ...                                        ; Data linked only if the related code (FirstFnc) is linked
+\c       ...                                        ; Data linked only if the related code
+\c                                                  ; (i.e. FirstFnc) is linked
 \c
 
 The defaults assumed by NASM if you do not specify the above


### PR DESCRIPTION
The long comment I added previously is truncated in PDF manual (so I just split it into two lines, hope it's gonna be OK now).