### PR TITLE
Adds indirect labels.

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -1432,8 +1432,13 @@ static Token *tokenize(const char *line)
                 }
                 while (nasm_isidchar(*p));
             } else if (*p == '%') {
-                /* %% operator */
                 p++;
+                if (*p == '[') {
+                    /* %%[ */
+                    p++;
+                } else {
+                    /* %% operator */
+                }
             }
 
             if (!ep)
@@ -1489,7 +1494,13 @@ static Token *tokenize(const char *line)
                     break;
 
                 case '%':
-                    type = (toklen == 2) ? TOKEN_SMOD : TOKEN_LOCAL_SYMBOL;
+                    if (toklen == 2) {
+                        type = TOKEN_SMOD;
+                    } else if (toklen >= 3 && line[2] == '[') {
+                        type = TOKEN_INDIRECT_ID;
+                    } else {
+                        type = TOKEN_LOCAL_SYMBOL;
+                    }
                     break;
 
                 case '$':

--- a/asm/stdscan.c
+++ b/asm/stdscan.c
@@ -310,8 +310,34 @@ int stdscan(void *private_data, struct tokenval *tv)
         stdscan_bufptr += 2;
         return tv->t_type = TOKEN_SDIV;
     } else if (stdscan_bufptr[0] == '%' && stdscan_bufptr[1] == '%') {
-        stdscan_bufptr += 2;
-        return tv->t_type = TOKEN_SMOD;
+        if(stdscan_bufptr[2] == '[') {
+            char start_quote;
+
+            stdscan_bufptr += 3;
+            stdscan_bufptr = nasm_skip_spaces(stdscan_bufptr);
+            if (*stdscan_bufptr != '\'' && *stdscan_bufptr != '"' &&
+                *stdscan_bufptr != '`') {
+                return tv->t_type = TOKEN_ERRSTR;
+            }
+
+            start_quote = *stdscan_bufptr;
+            tv->t_charptr = stdscan_bufptr;
+            tv->t_inttwo = nasm_unquote(tv->t_charptr, &stdscan_bufptr);
+            if (*stdscan_bufptr != start_quote)
+                return tv->t_type = TOKEN_ERRSTR;
+            stdscan_bufptr++;
+
+            stdscan_bufptr = nasm_skip_spaces(stdscan_bufptr);
+            if (*stdscan_bufptr != ']') {
+                return tv->t_type = TOKEN_ERRSTR;
+            }
+            stdscan_bufptr++;
+
+            return tv->t_type = TOKEN_ID;
+        } else {
+            stdscan_bufptr += 2;
+            return tv->t_type = TOKEN_SMOD;
+        }
     } else if (stdscan_bufptr[0] == '=' && stdscan_bufptr[1] == '=') {
         stdscan_bufptr += 2;
         return tv->t_type = TOKEN_EQ;

--- a/include/nasm.h
+++ b/include/nasm.h
@@ -262,6 +262,7 @@ enum token_type { /* token types, other than chars */
     TOKEN_PASTE,           /* %+ */
     TOKEN_COND_COMMA,      /* %, */
     TOKEN_INDIRECT,        /* %[...] */
+    TOKEN_INDIRECT_ID,     /* %%[ */
     TOKEN_XDEF_PARAM,      /* Used during %xdefine processing */
     /* smacro parameters starting here; an arbitrary number. */
     TOKEN_SMAC_START_PARAMS,    /* MUST BE LAST IN THE LIST!!! */


### PR DESCRIPTION
By writing `%%["some string"]`, the label `some string` will be referenced. Macros may expand to define the string part.

Mostly PRing this (at the stage it's at, i.e. before doc updates, with poor error reporting, without adding support to constructs that parse their own identifiers) for feedback on the idea. I'm doing something for which it's useful to put certain characters in the emitted symbols that aren't supported in labels; if there's a better way to do that (or to implement this), I'm open to suggestions.