### PR TITLE
CI: Create initial GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 6 * * 1'  # Each Monday at 06:00 UTC
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x' 
+    - run: ./autogen.sh
+    - run: ./configure
+    - run: make all
+    - run: python ./travis/nasm-t.py run


### PR DESCRIPTION
Create a simple CI workflow that runs the Python tests with using GitHub Actions. It runs on every push, pull request, once a week and when triggered manually.

This workflow replaces the old [Travis CI configuration](https://github.com/netwide-assembler/nasm/blob/master/.travis.yml), which isn't in use anymore.