### PR TITLE
Remove trailing semicolon in macros

### DIFF
--- a/asm/error.c
+++ b/asm/error.c
@@ -51,7 +51,7 @@
 		nasm_verror((_sev)|(_flags), fmt, ap);		\
 	va_end(ap);						\
 	if ((_sev) >= ERR_FATAL)                                \
-		abort();
+		abort()
 
 
 void nasm_error(errflags severity, const char *fmt, ...)

--- a/asm/listing.c
+++ b/asm/listing.c
@@ -51,7 +51,7 @@
 
 static const char xdigit[] = "0123456789ABCDEF";
 
-#define HEX(a,b) (*(a)=xdigit[((b)>>4)&15],(a)[1]=xdigit[(b)&15]);
+#define HEX(a,b) (*(a)=xdigit[((b)>>4)&15],(a)[1]=xdigit[(b)&15])
 
 uint64_t list_options, active_list_options;
 

--- a/include/error.h
+++ b/include/error.h
@@ -70,7 +70,7 @@ fatal_func printf_func(2, 3) nasm_criticalf(errflags flags, const char *fmt, ...
 fatal_func printf_func(1, 2) nasm_panic(const char *fmt, ...);
 fatal_func printf_func(2, 3) nasm_panicf(errflags flags, const char *fmt, ...);
 fatal_func nasm_panic_from_macro(const char *file, int line);
-#define panic() nasm_panic_from_macro(__FILE__, __LINE__);
+#define panic() nasm_panic_from_macro(__FILE__, __LINE__)
 
 void vprintf_func(2) nasm_verror(errflags severity, const char *fmt, va_list ap);
 fatal_func vprintf_func(2) nasm_verror_critical(errflags severity, const char *fmt, va_list ap);

--- a/include/nasmlib.h
+++ b/include/nasmlib.h
@@ -280,8 +280,7 @@ const char *filename_set_extension(const char *inname, const char *extension);
     for (pos = head, _n = (pos ? pos->next : NULL); pos; \
         pos = _n, _n = (_n ? _n->next : NULL))
 #define list_last(pos, head)                            \
-    for (pos = head; pos && pos->next; pos = pos->next) \
-        ;
+    for (pos = head; pos && pos->next; pos = pos->next)
 #define list_reverse(head)                              \
     do {                                                \
         void *_p, *_n;                                  \


### PR DESCRIPTION
Signed-off-by: Elyes Haouas <ehaouas@noos.fr>