### PR TITLE
fix undefined behavior in count_mmac_params

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -2519,6 +2519,9 @@ static Token **count_mmac_params(Token *tline, int *nparamp, Token ***paramsp)
                 }
             }
 
+            if (!t)
+                break;              /* End of string, no comma */
+
             /* Advance to the next comma */
             maybe_comma = &t->next;
             while (tok_isnt(t, ',')) {


### PR DESCRIPTION
When compiled `-fsanitize=undefined` nasm produced this error message:

```
asm/preproc.c:2523:25: runtime error: member access within null pointer of type 'struct Token'
```

The problem is reproducible on tests `avx512f`, `avx512cd`, `avx512pf` and `avx512er` in the test suite.

The problematic line was:

```
    /* Advance to the next comma */
    maybe_comma = &t->next;                            <<< HERE
    while (tok_isnt(t, ',')) {
        if (!tok_white(t))
            comma = NULL; /* Non-empty parameter */
        maybe_comma = &t->next;
        t = t->next;
    }
```

When `t` is `NULL` this line doesn't cause memory access, but it is still an undefined behavior according to C standard.

I believe that the underlying problem is that this loop doesn't have a sound invariant about `maybe_comma`:

* On first iteration: `*maybe_comma == t->next`
* On the following iterations: `*maybe_comma == t`

I don't know what the intended loop invariant is and I decided to just mechanically fix the deferencing of `NULL` pointer, completely preserving the existing behavior.