### PR TITLE
fix memory leak in -E mode

### DIFF
--- a/asm/nasm.c
+++ b/asm/nasm.c
@@ -630,7 +630,7 @@ int main(int argc, char **argv)
 
                 /* Skip blank lines if we will need a %line anyway */
                 if (linnum == -1 && !line[0])
-                    continue;
+                    goto done;
 
                 if (linnum != where.lineno) {
                     fprintf(ofile, "%%line %"PRId32"%+"PRId32" %s\n",
@@ -640,6 +640,9 @@ int main(int argc, char **argv)
 
                 fputs(line, ofile);
                 fputc('\n', ofile);
+
+            done:
+                nasm_free(line);
             }
 
             nasm_free(quoted_file_name);


### PR DESCRIPTION
When running with `-fsanitize=leak` enabled nasm prints these errors:

```
Direct leak of 114 byte(s) in 10 object(s) allocated from:
    #0 0x7f3031ef0867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x564dc07a2f6c in nasm_malloc nasmlib/alloc.c:55
    #2 0x564dc07f606a in detoken asm/preproc.c:2029
    #3 0x564dc0828a62 in pp_getline asm/preproc.c:7835
    #4 0x564dc0797f3e in main asm/nasm.c:654
    #5 0x7f3031608d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #6 0x7f3031608e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #7 0x564dc0799c24 in _start (/home/ivan/d/nasm/nasm+0x2e5c24)

Direct leak of 10 byte(s) in 10 object(s) allocated from:
    #0 0x7f3031ef0867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x564dc07a2f6c in nasm_malloc nasmlib/alloc.c:55
    #2 0x564dc07f64f9 in detoken asm/preproc.c:2029
    #3 0x564dc0828a62 in pp_getline asm/preproc.c:7835
    #4 0x564dc0797f3e in main asm/nasm.c:654
    #5 0x7f3031608d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #6 0x7f3031608e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #7 0x564dc0799c24 in _start (/home/ivan/d/nasm/nasm+0x2e5c24)
```

This is reproducible on tests that do preprocessing for example `weirdpaste` test.

The problem is caused by the fact that the line returned by `pp_getline` isn't freed in `main` function.