### PR TITLE
fix memory leak of MMacro::iname

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -986,6 +986,7 @@ static void free_mmacro(MMacro * m)
     free_tlist(m->dlist);
     nasm_free(m->defaults);
     free_llist(m->expansion);
+    nasm_free(m->iname);
     nasm_free(m);
 }
 
@@ -6899,6 +6900,7 @@ static int expand_mmacro(Token * tline)
     m->in_progress ++;
     m->params = params;
     m->iline = tline;
+    nasm_assert(!m->iname);
     m->iname = nasm_strdup(mname);
     m->nparam = nparam;
     m->rotate = 0;
@@ -7642,10 +7644,12 @@ static Token *pp_tokline(void)
                         nasm_free(m->params);
                         free_tlist(m->iline);
                         nasm_free(m->paramlen);
+                        nasm_free(m->iname);
                         fm->in_progress = 0;
                         m->params = NULL;
                         m->iline = NULL;
                         m->paramlen = NULL;
+                        m->iname = NULL;
                     }
                 }
 

--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -7643,9 +7643,9 @@ static Token *pp_tokline(void)
                         free_tlist(m->iline);
                         nasm_free(m->paramlen);
                         fm->in_progress = 0;
-			m->params = NULL;
-			m->iline = NULL;
-			m->paramlen = NULL;
+                        m->params = NULL;
+                        m->iline = NULL;
+                        m->paramlen = NULL;
                     }
                 }
 


### PR DESCRIPTION
fix memory leak of `MMacro::iname`

When running with `-fsanitize=leak` enabled nasm prints this error:

```
Direct leak of 25 byte(s) in 5 object(s) allocated from:
    #0 0x7f5fc494b867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    https://github.com/netwide-assembler/nasm/pull/1 0x55a8037f10e0 in nasm_malloc nasmlib/alloc.c:55
    https://github.com/netwide-assembler/nasm/pull/2 0x55a8037f10e0 in nasm_strdup nasmlib/alloc.c:117
    https://github.com/netwide-assembler/nasm/pull/3 0x55a803873172 in expand_mmacro asm/preproc.c:6905
    https://github.com/netwide-assembler/nasm/pull/4 0x55a803873172 in pp_tokline asm/preproc.c:7814
    https://github.com/netwide-assembler/nasm/pull/5 0x55a803873172 in pp_getline asm/preproc.c:7826
    https://github.com/netwide-assembler/nasm/pull/6 0x55a8037eb5d8 in assemble_file asm/nasm.c:1722
    https://github.com/netwide-assembler/nasm/pull/7 0x55a8037e5761 in main asm/nasm.c:719
    https://github.com/netwide-assembler/nasm/pull/8 0x7f5fc4063d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    https://github.com/netwide-assembler/nasm/pull/9 0x7f5fc4063e3f in __libc_start_main_impl ../csu/libc-start.c:392
    https://github.com/netwide-assembler/nasm/pull/10 0x55a8037e7c34 in _start (/home/ivan/d/nasm/nasm+0x2e5c34)

```

This is reproducible on many tests, for example on `zerobyte.asm`.

The problem was that `MMacro::iname` is only allocated but never freed.