### PR TITLE
fix memory leak of MMacro::name on macro undefining

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -3318,6 +3318,7 @@ static bool parse_mmacro_spec(Token *tline, MMacro *def, const char *directive)
 #if 0
     def->prev = NULL;
 #endif
+    nasm_assert(!def->name);
     def->name = dup_text(tline);
     def->plus = false;
     def->nolist = 0;
@@ -4615,12 +4616,14 @@ issue_error:
         if (!mmac_p) {
             /* No such macro */
             free_tlist(spec.dlist);
+            nasm_free(spec.name);
             break;
         }
 
         /* Check the macro to be undefined is not being expanded */
         list_for_each(l, istk->expansion) {
             if (l->finishes == *mmac_p) {
+                nasm_free(spec.name);
                 nasm_nonfatal("`%%unmacro' can't undefine the macro being expanded");
                 /*
                  * Do not release the macro instance to avoid using the freed
@@ -4644,6 +4647,7 @@ issue_error:
             }
         }
         free_tlist(spec.dlist);
+        nasm_free(spec.name);
         break;
     }
 


### PR DESCRIPTION
When running with `-fsanitize=leak` enabled nasm prints this error:

```
ERROR: LeakSanitizer: detected memory leaks

Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7f17d8a60867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x5613fd57401c in nasm_malloc nasmlib/alloc.c:55
    #2 0x5613fd5be840 in dup_text asm/preproc.c:436
    #3 0x5613fd5dc71d in parse_mmacro_spec asm/preproc.c:3325
    #4 0x5613fd5e5f7a in do_directive asm/preproc.c:4615
    #5 0x5613fd5f5e19 in pp_tokline asm/preproc.c:7766
    #6 0x5613fd5f5e19 in pp_getline asm/preproc.c:7830
    #7 0x5613fd56e678 in assemble_file asm/nasm.c:1722
    #8 0x5613fd568801 in main asm/nasm.c:719
    #9 0x7f17d8178d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #10 0x7f17d8178e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #11 0x5613fd56acd4 in _start (/home/ivan/d/nasm/nasm+0x2e5cd4)

SUMMARY: AddressSanitizer: 6 byte(s) leaked in 1 allocation(s).
```

This error was reproducible on `align13s.asm` test.

The problem was caused by the fact that `do_directive` didn't cleaup properly the macro name returned from `parse_mmacro_spec`.