### PR TITLE
fix leaked token text

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -1811,6 +1811,9 @@ static Token *delete_Token(Token *t)
     nasm_assert(t && t->type != TOKEN_FREE);
 
     next = t->next;
+
+    if (t->len > INLINE_TEXT)
+        nasm_free(t->text.p.ptr);
     nasm_zero(*t);
     t->type = TOKEN_FREE;
     t->next = freeTokens;


### PR DESCRIPTION
When running with `-fsanitize=leak` enabled nasm prints this error:

```
Direct leak of 3795 byte(s) in 5 object(s) allocated from:
    #0 0x7f1ff9313867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x56000dc80bc4 in nasm_malloc nasmlib/alloc.c:55
    #2 0x56000dcd526b in new_Token asm/preproc.c:1879
    #3 0x56000dcd4667 in tokenize asm/preproc.c:1748
    #4 0x56000dd0809f in pp_tokline asm/preproc.c:7718
    #5 0x56000dd09715 in pp_getline asm/preproc.c:7834
    #6 0x56000dc7c63c in assemble_file asm/nasm.c:1722
    #7 0x56000dc754e4 in main asm/nasm.c:719
    #8 0x7f1ff8a2bd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0x7f1ff8a2be3f in __libc_start_main_impl ../csu/libc-start.c:392
    #10 0x56000dc70e04 in _start (/home/ivan/d/nasm/nasm+0x2e2e04)
```

This error was reproducible on `testnos3.asm` test.