### PR TITLE
fix memory leak in find_label

### DIFF
--- a/asm/labels.c
+++ b/asm/labels.c
@@ -240,6 +240,8 @@ static union label *find_label(const char *label, bool create, bool *created)
     if (lptr || !create) {
         if (created)
             *created = false;
+        if (label_str)
+            nasm_free(label_str);
         return lptr;
     }
 


### PR DESCRIPTION
When running with `-fsanitize=leak` enabled nasm prints this error:

```
Direct leak of 504 byte(s) in 32 object(s) allocated from:
    #0 0x7f7274bf9867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x55a15e7bbbc4 in nasm_malloc nasmlib/alloc.c:55
    #2 0x55a15e7bc069 in nasm_strcat nasmlib/alloc.c:139
    #3 0x55a15e7f3968 in find_label asm/labels.c:235
    #4 0x55a15e7f61f7 in define_label asm/labels.c:462
    #5 0x55a15e7ff1ce in parse_line asm/parser.c:665
    #6 0x55a15e7b75f8 in assemble_file asm/nasm.c:1735
    #7 0x55a15e7b04e4 in main asm/nasm.c:719
    #8 0x7f7274311d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0x7f7274311e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #10 0x55a15e7abe04 in _start (/home/ivan/d/nasm/nasm+0x2e2e04)
```

This error was reproducible on `struc.asm` test.

The problem was that not all exit paths freed the allocated string.