### PR TITLE
fix memory leak in elf_init

### DIFF
--- a/output/outelf.c
+++ b/output/outelf.c
@@ -544,10 +544,13 @@ static void elf_init(void)
         ".shstrtab", ".strtab", ".symtab", ".symtab_shndx", NULL
     };
     const char * const *p;
-    const char * cur_path = nasm_realpath(inname);
+    char *cur_path = nasm_realpath(inname);
+    char *cur_path_dirname = nasm_dirname(cur_path);
 
     strlcpy(elf_module, inname, sizeof(elf_module));
-    strlcpy(elf_dir, nasm_dirname(cur_path), sizeof(elf_dir));
+    strlcpy(elf_dir, cur_path_dirname, sizeof(elf_dir));
+    nasm_free(cur_path);
+    nasm_free(cur_path_dirname);
     sects = NULL;
     nsects = sectlen = 0;
     syms = saa_init((int32_t)sizeof(struct elf_symbol));


### PR DESCRIPTION
When running with `-fsanitize=leak` enabled nasm prints this error:

```
Direct leak of 31 byte(s) in 1 object(s) allocated from:
    #0 0x7faadfc56867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7faadf3ecaac in __GI___libc_scratch_buffer_dupfree malloc/scratch_buffer_dupfree.c:32
    #2 0x7faadf395eed in scratch_buffer_dupfree ../include/scratch_buffer.h:147
    #3 0x7faadf395eed in realpath_stk stdlib/canonicalize.c:424
    #4 0x7faadf3964f5 in __GI___realpath stdlib/canonicalize.c:446
    #5 0x7faadfbe6b7c in __interceptor_canonicalize_file_name ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:3682
    #6 0x5643cfb1b058 in nasm_realpath nasmlib/realpath.c:58
    #7 0x5643cfaaaef5 in elf_init output/outelf.c:547
    #8 0x5643cfaaade7 in elf32_init output/outelf.c:496
    #9 0x5643cf9d1454 in main asm/nasm.c:716
    #10 0x7faadf36ed8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x7faadf36ee3f in __libc_start_main_impl ../csu/libc-start.c:392
    #12 0x5643cf9cce04 in _start (/home/ivan/d/nasm/nasm+0x2e2e04)

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7faadfc56867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x5643cf9dcbc4 in nasm_malloc nasmlib/alloc.c:55
    #2 0x5643cf9dced4 in nasm_strndup nasmlib/alloc.c:127
    #3 0x5643cfb1b4e4 in nasm_dirname nasmlib/path.c:152
    #4 0x5643cfaaaf4d in elf_init output/outelf.c:550
    #5 0x5643cfaaade7 in elf32_init output/outelf.c:496
    #6 0x5643cf9d1454 in main asm/nasm.c:716
    #7 0x7faadf36ed8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #8 0x7faadf36ee3f in __libc_start_main_impl ../csu/libc-start.c:392
    #9 0x5643cf9cce04 in _start (/home/ivan/d/nasm/nasm+0x2e2e04)
```

This error is reproducible on any test that is run with `-felf`.

The problem is fixed by calling nasm_free appropriately. I had to remove const from pointers because I get `-Wdiscarded-qualifiers` warning otherwise, because `nasm_free` takes non-const pointer.