### PR TITLE
fix memory leak in expand_mmac_params

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -5555,7 +5555,7 @@ static Token *expand_mmac_params(Token * tline)
             } else {
                 *tail = t;
                 tail = &t->next;
-		set_text(t, text, tok_strlen(text));
+                set_text_free(t, text, tok_strlen(text));
                 t->type = type;
             }
             changed = true;


### PR DESCRIPTION
When running with `-fsanitize=leak` enabled nasm prints this error:

```
Direct leak of 10 byte(s) in 5 object(s) allocated from:
    #0 0x7f52b6464867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x55cf36676bc4 in nasm_malloc nasmlib/alloc.c:55
    #2 0x55cf3667730d in nasm_vaxprintf nasmlib/asprintf.c:61
    #3 0x55cf36677618 in nasm_asprintf nasmlib/asprintf.c:90
    #4 0x55cf366e8b96 in expand_mmac_params asm/preproc.c:5451
    #5 0x55cf366fec7a in pp_tokline asm/preproc.c:7767
    #6 0x55cf366ff84a in pp_getline asm/preproc.c:7837
    #7 0x55cf3667263c in assemble_file asm/nasm.c:1722
    #8 0x55cf3666b4e4 in main asm/nasm.c:719
    #9 0x7f52b5b7cd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #10 0x7f52b5b7ce3f in __libc_start_main_impl ../csu/libc-start.c:392
    #11 0x55cf36666e04 in _start (/home/ivan/d/nasm/nasm+0x2e2e04)
```

This error is reproducing on `lnxhello.asm` test.