### PR TITLE
assemble: Use the last match error for error reporting

### DIFF
--- a/asm/assemble.c
+++ b/asm/assemble.c
@@ -2441,7 +2441,7 @@ static enum match_result find_match(const struct itemplate **tempp,
                     xsizeflags[i] |= temp->opd[i] & SIZE_MASK;
             opsizemissing = true;
         }
-        if (m > merr)
+        if (m)
             merr = m;
         if (merr == MOK_GOOD)
             goto done;
@@ -2482,7 +2482,7 @@ static enum match_result find_match(const struct itemplate **tempp,
             else
                 m = MERR_INVALOP;
         }
-        if (m > merr)
+        if (m)
             merr = m;
         if (merr == MOK_GOOD)
             goto done;


### PR DESCRIPTION
The issue with using the match error with the highest numerical value is that most instructions with a mask operand will always report a bogus "mask not permitted on this operand" error due to not matching with VEX instructions (which is normal and expected) even if the real error is something entirely different, such as an incorrect broadcast operand.