### PR TITLE
preproc: Fix makefile dependencies for included files.

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -2360,12 +2360,12 @@ static FILE *inc_fopen(const char *file,
                 fhe->full = full;
             }
         }
-
-        /*
-         * Add file to dependency path.
-         */
-        strlist_add(dhead, path ? path : file);
     }
+
+    /*
+     * Add file to dependency path.
+     */
+    strlist_add(dhead, path ? path : file);
 
     if (path && !fp && omode != INC_PROBE)
         fp = nasm_open_read(path, fmode);


### PR DESCRIPTION
A bug in 169ac7c152ee13ed0c470ceb3371e9afb10e9a60 caused inc_fopen to not add included files to the dependency list when using the -MD file option.  The reason is that the included files would only be added to the list on a hash table miss, but since the dependency list is generated in the final pass when the hash table is already fully populated, no include files would actually be added.

The fix is to always add an included file to the dependency list, regardless of the hash table hit status.

See also https://bugzilla.nasm.us/show_bug.cgi?id=3392832 