### PR TITLE
Fix CVE-2023-31722

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -6817,7 +6817,7 @@ static int expand_mmacro(Token * tline)
      */
     nasm_newn(paramlen, nparam+1);
 
-    for (i = 1; (t = params[i]); i++) {
+    for (i = 1; i < nparam+1 && (t = params[i]); i++) {
         bool braced = false;
         int brace = 0;
         int white = 0;

--- a/nasmlib/alloc.c
+++ b/nasmlib/alloc.c
@@ -104,8 +104,10 @@ void *nasm_realloc(void *q, size_t size)
 
 void nasm_free(void *q)
 {
-    if (q)
+    if (q){
         free(q);
+	q = NULL;
+    }
 }
 
 char *nasm_strdup(const char *s)


### PR DESCRIPTION
paramlen has heap memory of length nparam+1. The value of variable i may be greater than nparam+1, causing heap memory overflow. Therefore,  i and nparam+1 needs to be determined in the loop. 
Fix:https://bugzilla.nasm.us/show_bug.cgi?id=3392857#c1