### PR TITLE
debug: Add missing elements to types array

### DIFF
--- a/output/outdbg.c
+++ b/output/outdbg.c
@@ -409,7 +409,8 @@ dbg_pragma(const struct pragma *pragma)
 }
 
 static const char * const types[] = {
-    "unknown", "label", "byte", "word", "dword", "float", "qword", "tbyte"
+    "unknown", "label", "byte", "word", "dword", "float", "qword", "tbyte",
+    "oword", "yword", "zword"
 };
 static void dbgdbg_init(void)
 {


### PR DESCRIPTION
Bug 3392814 (Global-buffer-overflow output/outdbg.c in dbgdbg_typevalue) is caused by the array types[] are missing elements that correspond to the TY_OWORD, TY_YWORD and TY_ZWORD definitions in /include/nasm.h