### PR TITLE
Mach-O build version

### DIFF
--- a/asm/pragma.c
+++ b/asm/pragma.c
@@ -272,7 +272,16 @@ void process_pragma(char *str)
     else
         pragma.opcode = directive_find(pragma.opname);
 
-    pragma.tail = nasm_trim_spaces(p);
+    /*
+     * This used to use nasm_trim_spaces, but that assumes a single word.
+     * Instead, strip spaces at either end of the directive, but allow
+     * interior spaces.
+     */
+    p = nasm_zap_spaces_fwd(p);
+    pragma.tail = p;
+    p += strlen(p);
+    while (p > pragma.tail && nasm_isspace(p[-1]))
+	*--p = 0;
 
     /*
      * Search the global pragma namespaces. This is done

--- a/doc/outfmt.src
+++ b/doc/outfmt.src
@@ -1093,6 +1093,38 @@ this extension:
 Using with static linker will clear the private extern attribute.
 But linker option like \c{-keep_private_externs} can avoid it.
 
+\S{macho-bver} \c{macho} specific directive \i\c{build_version}
+
+The directive \c{build_version} generates a \c{LC_BUILD_VERSION}
+load command in the Mach-O header, which allows specifying a
+target platform, minimum OS version and optionally SDK version.
+Newer Xcode linker versions warn if this is not present in object
+files.
+
+This directive takes the target platform name and minimum OS
+version as arguments, in this form:
+
+\c build_version macos,10,7
+
+Platform names that make sense for x86 code are \c{macos},
+\c{iossimulator}, \c{tvossimulator} and \c{watchossimulator}.
+
+Optionally, a trailing version number and minimum SDK version
+can also be specified with this syntax:
+
+\c build_version macos, 10, 14, 0 sdk_version 10, 14, 0
+
+This is a macro implemented as a \c{%pragma}. It can also be
+specified in its \c{%pragma} form, in which case it will not
+affect non-Mach-O builds of the same source code:
+
+\c      %pragma macho build_version ...
+
+This latter form is also useful on the command line when using
+the \c{--pragma} command-line switch:
+
+\c      nasm -f macho64 --pragma "macho build_version macos,10,9" ...
+
 \H{elffmt} \i\c{elf32}, \i\c{elf64}, \i\c{elfx32}: \I{ELF}\I{linux, elf}\i{Executable and Linkable
 Format} Object Files
 

--- a/output/macho.h
+++ b/output/macho.h
@@ -60,6 +60,7 @@
 #define LC_SEGMENT			0x1
 #define LC_SEGMENT_64			0x19
 #define LC_SYMTAB			0x2
+#define LC_BUILD_VERSION		0x32
 
 /* Symbol type bits */
 #define N_STAB				0xe0
@@ -149,6 +150,24 @@
 #define VM_PROT_READ			0x01
 #define VM_PROT_WRITE			0x02
 #define VM_PROT_EXECUTE			0x04
+
+/* Platforms */
+/* X-macro X(_platform, _id, _name) */
+#define MACHO_ALL_PLATFORMS \
+	X(PLATFORM_UNKNOWN, 0, "unknown") \
+	X(PLATFORM_MACOS, 1, "macos") \
+	X(PLATFORM_IOS, 2, "ios") \
+	X(PLATFORM_TVOS, 3, "tvos") \
+	X(PLATFORM_WATCHOS, 4, "watchos") \
+	X(PLATFORM_BRIDGEOS, 5, "bridgeos") \
+	X(PLATFORM_MACCATALYST, 6, "macCatalyst") \
+	X(PLATFORM_IOSSIMULATOR, 7, "iossimulator") \
+	X(PLATFORM_TVOSSIMULATOR, 8, "tvossimulator") \
+	X(PLATFORM_WATCHOSSIMULATOR, 9, "watchossimulator") \
+	X(PLATFORM_DRIVERKIT, 10, "driverkit") \
+	X(PLATFORM_XROS, 11, "xros") \
+	X(PLATFORM_XROS_SIMULATOR, 12, "xrsimulator") \
+	/* end */
 
 typedef struct {
 	uint32_t	magic;
@@ -278,5 +297,21 @@ typedef struct {
 	uint16_t	n_desc;
 	uint64_t	n_value;
 } macho_nlist_64_t;
+
+/* Adapted from LLVM include/llvm/BinaryFormat/MachO.h */
+typedef struct {
+	uint32_t	tool;
+	uint32_t	version;
+} macho_build_tool_version_t;
+
+typedef struct {
+	uint32_t	cmd;
+	uint32_t	cmdsize;
+	uint32_t	platform;
+	uint32_t	minos;		/* x.y.z is 0xXXXXYYZZ */
+	uint32_t	sdk;		/* x.y.z is 0xXXXXYYZZ */
+	uint32_t	ntools;
+	/* ntools macho_build_tool_version_t follow this */
+} macho_build_version_command_t;
 
 #endif /* OUTPUT_MACHO_H */

--- a/output/outmacho.mac
+++ b/output/outmacho.mac
@@ -47,3 +47,9 @@ OUT: macho macho32 macho64
         %rotate 1
     %endrep
 %endmacro
+
+; This sets LC_BUILD_VERSION in the object file, analogous to as .build_version
+%imacro build_version 3+
+    %pragma __?OUTPUT_FORMAT?__ %? %1,%2,%3
+%endmacro
+


### PR DESCRIPTION
Add a build_version directive for Mach-O emitting LC_BUILD_VERSION

Newer Xcode linkers warn when this is not present. This has overlap with issue #13,
but this implementation adds a `build_version` directive matching llvm-as `.build_version`
syntax to the Mach-O format. This is implemented as a pragma internally which
allows both specifying in the source (matching how it's normally used in llvm-as)
and on the command line via the `--pragma` command-line option.

I'm not aware of any "official" documentation of the llvm-as `.build_version` syntax,
so I worked off the parser in https://github.com/llvm/llvm-project/blob/main/llvm/lib/MC/MCParser/DarwinAsmParser.cpp