### PR TITLE
Disable other warnings in endstruc

### DIFF
--- a/macros/standard.mac
+++ b/macros/standard.mac
@@ -89,7 +89,10 @@ STD: nasm
 %imacro endstruc 0.nolist
         %{$strucname}_size equ ($-%$strucname)
     %pop
+    [warning push]
+    [warning -other]
     __?SECT?__
+    [warning pop]
 %endmacro
 
 %imacro istruc 1.nolist


### PR DESCRIPTION
endstruc calls __?SECT?__ and this causes unnecessary warnings on obj output if a section is defined with any attributes, because obj output does not like a segment definition with any attributes when it appears again.