### PR TITLE
Improve FLAT support

### DIFF
--- a/output/outobj.c
+++ b/output/outobj.c
@@ -1536,7 +1536,12 @@ static int32_t obj_segment(char *name, int *bits)
                     nasm_free(grp->segs[i].name);
                     grp->segs[i] = grp->segs[grp->nindices];
                     grp->segs[grp->nindices++].index = seg->obj_index;
-                    if (seg->grp)
+                    /*
+                     * The group FLAT is a pseudo group. Therefore, it is
+                     * allowed to redefine a segment in the group FLAT as
+                     * other group.
+                     */
+                    if (seg->grp && strcmp(seg->grp->name, "FLAT"))
                         nasm_warn(WARN_OTHER, "segment `%s' is already part of"
                                   " a group: first one takes precedence",
                                   seg->name);
@@ -1651,7 +1656,12 @@ obj_directive(enum directive directive, char *value)
                      */
                     grp->segs[grp->nentries++] = grp->segs[grp->nindices];
                     grp->segs[grp->nindices++].index = seg->obj_index;
-                    if (seg->grp)
+                    /*
+                     * The group FLAT is a pseudo group. Therefore, it is
+                     * allowed to redefine a segment in the group FLAT as
+                     * other group.
+                     */
+                    if (seg->grp && strcmp(seg->grp->name, "FLAT"))
                         nasm_warn(WARN_OTHER, "segment `%s' is already part of"
                                   " a group: first one takes precedence",
                                   seg->name);

--- a/output/outobj.c
+++ b/output/outobj.c
@@ -1517,6 +1517,9 @@ static int32_t obj_segment(char *name, int *bits)
             }
         }
 
+        if (!seg->use32 && seg->grp && !strcmp(seg->grp->name, "FLAT"))
+           nasm_panic("wrong combination of USE16(16-bit segment) and FLAT");
+
         /* We need to know whenever we have at least one 32-bit segment */
         obj_use32 |= seg->use32;
 


### PR DESCRIPTION
Hi/2.

This PR improves FLAT support.

1. Allow to redefine a segment in the group FLAT as other group.
2. Disallow the combination of USE16 and FLAT.

Thanks!