### PR TITLE
nasm: show buffered warnings correctly

### DIFF
--- a/asm/nasm.c
+++ b/asm/nasm.c
@@ -1691,8 +1691,10 @@ static void assemble_file(const char *fname, struct strlist *depend_list)
          * pass 2 (everything will be emitted immediately in pass 2.)
 	 */
 	if (warn_list) {
-            if (warn_list->nstr || pass_final())
+            if (warn_list->nstr || pass_final()) {
+                strlist_write(warn_list, "\n", error_file);
                 strlist_free(&warn_list);
+            }
         }
 
 	if (!pass_final() && !warn_list)


### PR DESCRIPTION
Print buffered warnings before free them.