### PR TITLE
Add prefetching on strings before hashing

### DIFF
--- a/nasmlib/hashtbl.c
+++ b/nasmlib/hashtbl.c
@@ -110,6 +110,8 @@ void **hash_findb(struct hash_table *head, const void *key,
 void **hash_find(struct hash_table *head, const char *key,
                  struct hash_insert *insert)
 {
+    __builtin_prefetch(key);
+
     return hash_findb(head, key, strlen(key)+1, insert);
 }
 
@@ -154,6 +156,8 @@ void **hash_findib(struct hash_table *head, const void *key, size_t keylen,
 void **hash_findi(struct hash_table *head, const char *key,
                   struct hash_insert *insert)
 {
+    __builtin_prefetch(key);
+
     return hash_findib(head, key, strlen(key)+1, insert);
 }
 

--- a/nasmlib/strlist.c
+++ b/nasmlib/strlist.c
@@ -78,6 +78,8 @@ strlist_add(struct strlist *list, const char *str)
 	struct hash_insert hi;
 	size_t size;
 
+	__builtin_prefetch(str);
+
 	if (!list)
 		return NULL;
 


### PR DESCRIPTION
Turns out that the hotspots of nasm are mainly on string hashing when accessing memory. A simple performance improvement is to prefetch the first cacheline of a string to be hashed. Ran 50 tests on an i9-12900 building intel-ipsec-mb that heavily uses nasm and improved wall clock build times from 56.1 seconds to 53.2 seconds or around 5% speed improvement.