### PR TITLE
x86: SM4-NI EVEX support

### DIFF
--- a/test/sm4-64.asm
+++ b/test/sm4-64.asm
@@ -10,6 +10,21 @@ BITS 64
 	vsm4rnds4 ymm3, ymm4, [rax+0x12]
 	vsm4rnds4 ymm4, ymm5, [rax+rbx*2]
 
+	vsm4rnds4 xmm16, xmm16, xmm0
+	vsm4rnds4 xmm17, xmm17, [rax]
+	vsm4rnds4 xmm18, xmm18, [rax+0x12]
+	vsm4rnds4 xmm19, xmm19, [rax+rbx*2]
+
+	vsm4rnds4 ymm16, ymm16, ymm0
+	vsm4rnds4 ymm17, ymm17, [rax]
+	vsm4rnds4 ymm18, ymm18, [rax+0x12]
+	vsm4rnds4 ymm19, ymm19, [rax+rbx*2]
+
+	vsm4rnds4 zmm16, zmm16, zmm0
+	vsm4rnds4 zmm17, zmm17, [rax]
+	vsm4rnds4 zmm18, zmm18, [rax+0x12]
+	vsm4rnds4 zmm19, zmm19, [rax+rbx*2]
+
 	vsm4key4 xmm1, xmm2, xmm0
 	vsm4key4 xmm2, xmm3, [rax]
 	vsm4key4 xmm3, xmm4, [rax+0x12]
@@ -19,3 +34,18 @@ BITS 64
 	vsm4key4 ymm2, ymm3, [rax]
 	vsm4key4 ymm3, ymm4, [rax+0x12]
 	vsm4key4 ymm4, ymm5, [rax+rbx*2]
+
+	vsm4key4 xmm16, xmm16, xmm0
+	vsm4key4 xmm17, xmm17, [rax]
+	vsm4key4 xmm18, xmm18, [rax+0x12]
+	vsm4key4 xmm19, xmm19, [rax+rbx*2]
+
+	vsm4key4 ymm16, ymm16, ymm0
+	vsm4key4 ymm17, ymm17, [rax]
+	vsm4key4 ymm18, ymm18, [rax+0x12]
+	vsm4key4 ymm19, ymm19, [rax+rbx*2]
+
+	vsm4key4 zmm16, zmm16, zmm0
+	vsm4key4 zmm17, zmm17, [rax]
+	vsm4key4 zmm18, zmm18, [rax+0x12]
+	vsm4key4 zmm19, zmm19, [rax+rbx*2]

--- a/test/sm4.asm
+++ b/test/sm4.asm
@@ -10,6 +10,21 @@ BITS 32
 	vsm4rnds4 ymm3, ymm4, [eax+0x12]
 	vsm4rnds4 ymm4, ymm5, [eax+ebx*2]
 
+	vsm4rnds4 xmm16, xmm16, xmm0
+	vsm4rnds4 xmm17, xmm17, [eax]
+	vsm4rnds4 xmm18, xmm18, [eax+0x12]
+	vsm4rnds4 xmm19, xmm19, [eax+ebx*2]
+
+	vsm4rnds4 ymm16, ymm16, ymm0
+	vsm4rnds4 ymm17, ymm17, [eax]
+	vsm4rnds4 ymm18, ymm18, [eax+0x12]
+	vsm4rnds4 ymm19, ymm19, [eax+ebx*2]
+
+	vsm4rnds4 zmm16, zmm16, zmm0
+	vsm4rnds4 zmm17, zmm17, [eax]
+	vsm4rnds4 zmm18, zmm18, [eax+0x12]
+	vsm4rnds4 zmm19, zmm19, [eax+ebx*2]
+
 	vsm4key4 xmm1, xmm2, xmm0
 	vsm4key4 xmm2, xmm3, [eax]
 	vsm4key4 xmm3, xmm4, [eax+0x12]
@@ -19,3 +34,18 @@ BITS 32
 	vsm4key4 ymm2, ymm3, [eax]
 	vsm4key4 ymm3, ymm4, [eax+0x12]
 	vsm4key4 ymm4, ymm5, [eax+ebx*2]
+
+	vsm4key4 xmm16, xmm16, xmm0
+	vsm4key4 xmm17, xmm17, [eax]
+	vsm4key4 xmm18, xmm18, [eax+0x12]
+	vsm4key4 xmm19, xmm19, [eax+ebx*2]
+
+	vsm4key4 ymm16, ymm16, ymm0
+	vsm4key4 ymm17, ymm17, [eax]
+	vsm4key4 ymm18, ymm18, [eax+0x12]
+	vsm4key4 ymm19, ymm19, [eax+ebx*2]
+
+	vsm4key4 zmm16, zmm16, zmm0
+	vsm4key4 zmm17, zmm17, [eax]
+	vsm4key4 zmm18, zmm18, [eax+0x12]
+	vsm4key4 zmm19, zmm19, [eax+ebx*2]

--- a/x86/insns.dat
+++ b/x86/insns.dat
@@ -3598,9 +3598,12 @@ VSM3RNDS2       xmmreg,xmmreg,xmmreg,imm8           [rvmi: vex.nds.128.66.0f3a.w
 
 ;# SM4
 VSM4KEY4        xmmreg,xmmreg,xmmrm128              [rvm: vex.nds.128.f3.0f38.w0 da /r] SM4,AVX,FUTURE
-VSM4KEY4        ymmreg,ymmreg,ymmrm128              [rvm: vex.nds.256.f3.0f38.w0 da /r] SM4,AVX,FUTURE
+VSM4KEY4        ymmreg,ymmreg,ymmrm256              [rvm: vex.nds.256.f3.0f38.w0 da /r] SM4,AVX,FUTURE
 VSM4RNDS4       xmmreg,xmmreg,xmmrm128              [rvm: vex.nds.128.f2.0f38.w0 da /r] SM4,AVX,FUTURE
-VSM4RNDS4       ymmreg,ymmreg,ymmrm128              [rvm: vex.nds.256.f2.0f38.w0 da /r] SM4,AVX,FUTURE
+VSM4RNDS4       ymmreg,ymmreg,ymmrm256              [rvm: vex.nds.256.f2.0f38.w0 da /r] SM4,AVX,FUTURE
+VSM4RNDS4       xmmreg,xmmreg,xmmrm128              [rvm: evex.nds.128.f2.0f38.w0 da /r] SM4,AVX,FUTURE
+VSM4RNDS4       ymmreg,ymmreg,ymmrm256              [rvm: evex.nds.256.f2.0f38.w0 da /r] SM4,AVX,FUTURE
+VSM4RNDS4       zmmreg,zmmreg,zmmrm512              [rvm: evex.nds.512.f2.0f38.w0 da /r] SM4,AVX,FUTURE
 
 ;# AVX no exception conversions
 ; Must precede AVX-512 versions


### PR DESCRIPTION
Add EVEX-encoded SM4-NI instructions.

Signed-off-by: Pablo de Lara <pablo.de.lara.guarch@intel.com>