### PR TITLE
all: reduce type, align for 64-bit, using autopadding memholes after swap fields

### DIFF
--- a/asm/labels.c
+++ b/asm/labels.c
@@ -115,9 +115,9 @@ union label {                   /* actual label structures */
         enum label_type type, mangled_type;
     } defn;
     struct {
-        int32_t movingon;
         int64_t dummy;
         union label *next;
+        int32_t movingon;
     } admin;
 };
 

--- a/disasm/disasm.c
+++ b/disasm/disasm.c
@@ -76,6 +76,9 @@
  * Prefix information
  */
 struct prefix_info {
+    uint32_t rex;       /* REX prefix present */
+    uint8_t evex[3];    /* EVEX prefix present */
+
     uint8_t osize;      /* Operand size */
     uint8_t asize;      /* Address size */
     uint8_t osp;        /* Operand size prefix present */
@@ -89,8 +92,6 @@ struct prefix_info {
     uint8_t vex_m;      /* VEX.M field */
     uint8_t vex_v;
     uint8_t vex_lp;     /* VEX.LP fields */
-    uint32_t rex;       /* REX prefix present */
-    uint8_t evex[3];    /* EVEX prefix present */
 };
 
 #define getu8(x) (*(uint8_t *)(x))

--- a/include/nasm.h
+++ b/include/nasm.h
@@ -60,10 +60,10 @@ extern const char *_progname;
 /* Time stamp for the official start of compilation */
 struct compile_time {
     time_t t;
-    bool have_local, have_gm, have_posix;
     int64_t posix;
     struct tm local;
     struct tm gm;
+    bool have_local, have_gm, have_posix;
 };
 extern struct compile_time official_compile_time;
 
@@ -314,10 +314,10 @@ struct tokenval {
     char                *t_charptr;
     int64_t             t_integer;
     int64_t             t_inttwo;
+    const char		    *t_start; /* Pointer to token in input buffer */
+    int			        t_len;    /* Length of token in input buffer */
     enum token_type     t_type;
     int8_t              t_flag;
-    const char		*t_start; /* Pointer to token in input buffer */
-    int			t_len;    /* Length of token in input buffer */
 };
 typedef int (*scanner)(void *private_data, struct tokenval *tv);
 
@@ -760,15 +760,15 @@ typedef struct insn { /* an instruction itself */
     int             eops_float;             /* true if DD and floating */
     int32_t         times;                  /* repeat count (TIMES prefix) */
     bool            rex_done;               /* REX prefix emitted? */
+    uint8_t         evex_p[3];              /* EVEX.P0: [RXB,R',00,mm], P1: [W,vvvv,1,pp] */
+                                            /* EVEX.P2: [z,L'L,b,V',aaa] */
     int             rex;                    /* Special REX Prefix */
     int             vexreg;                 /* Register encoded in VEX prefix */
     int             vex_cm;                 /* Class and M field for VEX prefix */
     int             vex_wlp;                /* W, P and L information for VEX prefix */
-    uint8_t         evex_p[3];              /* EVEX.P0: [RXB,R',00,mm], P1: [W,vvvv,1,pp] */
-                                            /* EVEX.P2: [z,L'L,b,V',aaa] */
-    enum ttypes     evex_tuple;             /* Tuple type for compressed Disp8*N */
     int             evex_rm;                /* static rounding mode for AVX512 (EVEX) */
     struct operand *evex_brerop;            /* BR/ER/SAE operand position */
+    enum ttypes     evex_tuple;             /* Tuple type for compressed Disp8*N */
 } insn;
 
 /* Instruction flags type: IF_* flags are defined in insns.h */

--- a/output/codeview.c
+++ b/output/codeview.c
@@ -82,15 +82,16 @@ struct source_file;
 struct source_file {
     const char *filename;
     char *fullname;
-    uint32_t fullnamelen;
 
     struct source_file *next;
+
+    uint32_t fullnamelen;
 
     uint32_t filetbl_off;
     uint32_t sourcetbl_off;
 
-    struct SAA *lines;
     uint32_t num_lines;
+    struct SAA *lines;
 
     unsigned char md5sum[MD5_HASHBYTES];
 };
@@ -110,13 +111,8 @@ enum symbol_type {
 };
 
 struct cv8_symbol {
-    enum symbol_type type;
     char *name;
-
-    uint32_t secrel;
-    uint16_t section;
-    uint32_t size;
-    uint32_t typeindex;
+    enum symbol_type type;
 
     enum symtype {
         TYPE_UNREGISTERED = 0x0000, /* T_NOTYPE */
@@ -132,13 +128,16 @@ struct cv8_symbol {
         TYPE_REAL256= 0x0044,
         TYPE_REAL512= 0x0045
     } symtype;
+
+    uint32_t secrel;
+    uint32_t size;
+    uint32_t typeindex;
+    uint16_t section;
 };
 
 struct cv8_state {
     int symbol_sect;
     int type_sect;
-
-    uint32_t text_offset;
 
     struct source_file *source_files, **source_files_tail;
     const char *last_filename;
@@ -147,7 +146,7 @@ struct cv8_state {
     unsigned num_files;
     uint32_t total_filename_len;
 
-
+    uint32_t text_offset;
     unsigned total_lines;
 
     struct SAA *symbols;

--- a/output/outaout.c
+++ b/output/outaout.c
@@ -74,10 +74,10 @@ struct Symbol {
     int32_t value;                 /* address, or COMMON variable size */
     int32_t size;                  /* size for data or function exports */
     int32_t segment;               /* back-reference used by gsym_reloc */
+    int32_t symnum;                /* index into symbol table */
     struct Symbol *next;        /* list of globals in each section */
     struct Symbol *nextfwd;     /* list of unresolved-size symbols */
     char *name;                 /* for unresolved-size symbols */
-    int32_t symnum;                /* index into symbol table */
 };
 
 /*

--- a/output/outbin.c
+++ b/output/outbin.c
@@ -115,7 +115,6 @@ static struct Section {
     int64_t length;                /* section length in bytes */
 
 /* Section attributes */
-    int flags;                  /* see flag definitions above */
     uint64_t align;        /* section alignment */
     uint64_t valign;       /* notional section alignment */
     uint64_t start;        /* section start address */
@@ -129,6 +128,8 @@ static struct Section {
     struct bin_label **labels_end;      /* Holds address of end of labels list. */
     struct Section *prev;       /* Points to previous section (implicit follows). */
     struct Section *next;       /* This links sections with a defined start address. */
+
+    int flags;                  /* see flag definitions above */
 
 /* The extended bin format allows for sections to have a "virtual"
  * start address.  This is accomplished by creating two sections:

--- a/output/outcoff.c
+++ b/output/outcoff.c
@@ -822,8 +822,8 @@ static void coff_sect_write(struct coff_Section *sect,
 
 typedef struct tagString {
     struct tagString *next;
-    int len;
     char *String;
+    int len;
 } STRING;
 
 #define EXPORT_SECTION_NAME ".drectve"

--- a/output/outdbg.c
+++ b/output/outdbg.c
@@ -52,8 +52,8 @@
 
 struct Section {
     struct Section *next;
-    int32_t number;
     char *name;
+    int32_t number;
 } *dbgsect;
 
 static unsigned long dbg_max_data_dump = 128;

--- a/output/outelf.c
+++ b/output/outelf.c
@@ -116,8 +116,8 @@ static int sec_debug;
 struct symlininfo {
     int                 offset;
     int                 section;        /* index into sects[] */
-    int                 segto;          /* internal section number */
     char                *name;          /* shallow-copied pointer of section name */
+    int                 segto;          /* internal section number */
 };
 
 struct linelist {

--- a/output/outelf.h
+++ b/output/outelf.h
@@ -118,7 +118,6 @@ struct elf_section {
     uint64_t            nrelocs;
     int32_t             index;		/* NASM index or NO_SEG if internal */
     int			shndx;          /* ELF index */
-    int                 type;           /* SHT_* */
     uint64_t            align;          /* alignment: power of two */
     uint64_t            flags;          /* section flags */
     int64_t		pass_last_seen;
@@ -128,6 +127,7 @@ struct elf_section {
     struct elf_reloc    *head;
     struct elf_reloc    **tail;
     struct rbtree       *gsyms;         /* global symbols in section */
+    int                 type;           /* SHT_* */
 };
 
 #endif /* OUTPUT_OUTELF_H */

--- a/output/outieee.c
+++ b/output/outieee.c
@@ -164,6 +164,10 @@ struct ieeeObjData {
 
 struct ieeeFixupp {
     struct ieeeFixupp *next;
+    int32_t id1;
+    int32_t id2;
+    int32_t offset;
+    int32_t addend;
     enum {
         FT_SEG = 0,
         FT_REL = 1,
@@ -175,10 +179,6 @@ struct ieeeFixupp {
         FT_EXTSEG = 7
     } ftype;
     int16_t size;
-    int32_t id1;
-    int32_t id2;
-    int32_t offset;
-    int32_t addend;
 };
 
 static int32_t ieee_entry_seg, ieee_entry_ofs;

--- a/output/outlib.h
+++ b/output/outlib.h
@@ -116,13 +116,13 @@ struct ol_symhead {
 };
 
 struct ol_sect {
-    uint32_t flags;             /* Section/symbol flags */
     struct ol_sect *next;       /* Next section in declared order */
     const char *name;           /* Name of section */
     struct ol_symhead syml;     /* All symbols in this section */
     struct ol_symhead symg;     /* Global symbols in this section */
     struct SAA *data;           /* Contents of section */
     struct SAA *reloc;          /* Section relocations */
+    uint32_t flags;             /* Section/symbol flags */
     uint32_t index;             /* Primary section index */
     uint32_t subindex;          /* Current subsection index */
 };

--- a/output/outmacho.c
+++ b/output/outmacho.c
@@ -112,21 +112,10 @@ static void fwriteptr(uint64_t data, FILE * fp)
 }
 
 struct section {
-    /* nasm internal data */
-    struct section *next;
-    struct SAA *data;
-    int32_t index;		/* Main section index */
-    int32_t subsection;		/* Current subsection index */
-    int32_t fileindex;
-    struct reloc *relocs;
-    struct rbtree *syms[2]; /* All/global symbols symbols in section */
-    int align;
-    bool by_name;	    /* This section was specified by full MachO name */
-    char namestr[34];	    /* segment,section as a C string */
-
     /* data that goes into the file */
-    char sectname[16];     /* what this section is called */
-    char segname[16];      /* segment this section will be in */
+    char sectname[16]; /* what this section is called */
+    char segname[16]; /* segment this section will be in */
+
     uint64_t addr;         /* in-memory address (subject to alignment) */
     uint64_t size;         /* in-memory and -file size  */
     uint64_t offset;	   /* in-file offset */
@@ -134,6 +123,18 @@ struct section {
     uint32_t nreloc;       /* relocation entry count */
     uint32_t flags;        /* type and attributes (masked) */
     uint32_t extreloc;     /* external relocations */
+
+	/* nasm internal data */
+	struct section *next;
+	struct SAA *data;
+	int32_t index;		/* Main section index */
+	int32_t subsection;		/* Current subsection index */
+	struct reloc *relocs;
+	struct rbtree *syms[2]; /* All/global symbols symbols in section */
+	char namestr[34];	    /* segment,section as a C string */
+	int align;         /* align changed int -> int16_t for reduce cache size and fill mem holes */
+	uint32_t fileindex;
+	bool by_name;	       /* This section was specified by full MachO name */
 };
 
 #define S_NASM_TYPE_MASK	 0x800004ff	/* we consider these bits "section type" */
@@ -300,8 +301,8 @@ struct file_list {
     struct file_list *next;
     struct file_list *last;
     const char *file_name;
-    uint32_t file;
     struct dir_list *dir;
+	uint32_t file;
 };
 
 struct dw_sect_list {
@@ -309,9 +310,9 @@ struct dw_sect_list {
     int32_t section;
     uint32_t line;
     uint64_t offset;
-    uint32_t file;
     struct dw_sect_list *next;
     struct dw_sect_list *last;
+	uint32_t file;
 };
 
 struct section_info {

--- a/output/outobj.c
+++ b/output/outobj.c
@@ -613,8 +613,8 @@ static struct ImpDef {
     struct ImpDef *next;
     char *extname;
     char *libname;
-    unsigned int impindex;
     char *impname;
+    unsigned int impindex;
 } *imphead, **imptail;
 
 static struct ExpDef {

--- a/output/pecoff.h
+++ b/output/pecoff.h
@@ -476,24 +476,24 @@
 
 struct coff_Section {
     struct SAA *data;
+    struct coff_Reloc *head, **tail;
     uint32_t len;
     int nrelocs;
     int32_t index;
-    struct coff_Reloc *head, **tail;
     uint32_t flags;             /* section flags */
     uint32_t align_flags;       /* user-specified alignment flags */
     uint32_t sectalign_flags;   /* minimum alignment from sectalign */
     char *name;
+    int64_t pass_last_seen;
     int32_t namepos;            /* Offset of name into the strings table */
     int32_t pos, relpos;
-    int64_t pass_last_seen;
 
     /* comdat-related members */
-    char *comdat_name;
     uint32_t checksum;          /* set only for comdat sections */
+    char *comdat_name;
+    int32_t comdat_associated;  /* associated section for selection==5 */
     int8_t comdat_selection;
     int8_t comdat_symbol;       /* is the "comdat name" in symbol table? */
-    int32_t comdat_associated;  /* associated section for selection==5 */
 };
 
 struct coff_Reloc {
@@ -509,11 +509,11 @@ struct coff_Reloc {
 };
 
 struct coff_Symbol {
-    char name[9];
     int32_t strpos;             /* string table position of name */
     int32_t value;              /* address, or COMMON variable size */
     int section;                /* section number where it's defined
                                  * - in COFF codes, not NASM codes */
+    char name[9];
     bool is_global;             /* is it a global symbol or not? */
     int16_t type;               /* 0 - notype, 0x20 - function */
     int32_t namlen;             /* full name length */


### PR DESCRIPTION
@tkanteck, @hpax 

Using Pahole memory struct/class analyzer (from Red Hat https://linux.die.net/man/1/pahole) on object files after compilation, you can find places that are problematic for CPU cache, C/C++ compiler does not have automatic filling and alignment memholes and relies on programmer, since struct packaging can break behavior program, and for this there are keywords for packaging structures.

I also tried to keep previous order fields so as not to break style code.

I did not find in the documentation how to run nasm benchmark to compare PR and master, but in any case, leveling and reducing the size of structures reduces RAM usage since they can fit into the processor cache line.

I don't mind running a benchmark if someone tells me how. Maybe build speed on especially large projects will really be different.

### Reduce type sizes:

- section-align  int -> int16_t
- section-fileindex  uint32_t -> uint16_t

### Reduce structure sizes:

- section         168     160     saved 8 bytes (using type size reduce)
- coff_Section    112     96      saved 16 bytes
- cv8_symbol      40      32      saved 8 bytes
- cv8_state       152     144     saved 8 bytes
- Symbol          56      48      saved 8 bytes

### Pahole example output with `struct coff_Section`:

- Comment `/* XXX {n} bytes hole, try to pack */` shows where optimization is possible by rearranging the order of fields structures and classes or swap to end struct for autopadding by compiler

### Master branch

```c
debian@debian:~/GIT/nasm$ ~/GIT/dwarves/build/pahole --class_name=coff_Section */*.o
struct coff_Section {
        struct SAA *               data;                 /*     0     8 */
        uint32_t                   len;                  /*     8     4 */
        int                        nrelocs;              /*    12     4 */
        int32_t                    index;                /*    16     4 */

        /* XXX 4 bytes hole, try to pack */

        struct coff_Reloc *        head;                 /*    24     8 */
        struct coff_Reloc * *      tail;                 /*    32     8 */
        uint32_t                   flags;                /*    40     4 */
        uint32_t                   align_flags;          /*    44     4 */
        uint32_t                   sectalign_flags;      /*    48     4 */

        /* XXX 4 bytes hole, try to pack */

        char *                     name;                 /*    56     8 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        int32_t                    namepos;              /*    64     4 */
        int32_t                    pos;                  /*    68     4 */
        int32_t                    relpos;               /*    72     4 */

        /* XXX 4 bytes hole, try to pack */

        int64_t                    pass_last_seen;       /*    80     8 */
        char *                     comdat_name;          /*    88     8 */
        uint32_t                   checksum;             /*    96     4 */
        int8_t                     comdat_selection;     /*   100     1 */
        int8_t                     comdat_symbol;        /*   101     1 */

        /* XXX 2 bytes hole, try to pack */

        int32_t                    comdat_associated;    /*   104     4 */

        /* size: 112, cachelines: 2, members: 19 */
        /* sum members: 94, holes: 4, sum holes: 14 */
        /* padding: 4 */
        /* last cacheline: 48 bytes */
};

```

### PR

```c
debian@debian:~/GIT/nasm$ ~/GIT/dwarves/build/pahole --reorganize -S --class_name=coff_Section */*.o
struct coff_Section {
        struct SAA *               data;                 /*     0     8 */
        struct coff_Reloc *        head;                 /*     8     8 */
        struct coff_Reloc * *      tail;                 /*    16     8 */
        uint32_t                   len;                  /*    24     4 */
        int                        nrelocs;              /*    28     4 */
        int32_t                    index;                /*    32     4 */
        uint32_t                   flags;                /*    36     4 */
        uint32_t                   align_flags;          /*    40     4 */
        uint32_t                   sectalign_flags;      /*    44     4 */
        char *                     name;                 /*    48     8 */
        int64_t                    pass_last_seen;       /*    56     8 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        int32_t                    namepos;              /*    64     4 */
        int32_t                    pos;                  /*    68     4 */
        int32_t                    relpos;               /*    72     4 */
        uint32_t                   checksum;             /*    76     4 */
        char *                     comdat_name;          /*    80     8 */
        int32_t                    comdat_associated;    /*    88     4 */
        int8_t                     comdat_selection;     /*    92     1 */
        int8_t                     comdat_symbol;        /*    93     1 */

        /* size: 96, cachelines: 2, members: 19 */
        /* padding: 2 */
        /* last cacheline: 32 bytes */
};
```

## References:

https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml

https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf

https://en.wikipedia.org/wiki/Data_structure_alignment

https://stackoverflow.com/a/20882083

https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/