### PR TITLE
Fix memory leak in expand_mmac_params

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -5621,6 +5621,7 @@ static Token *expand_mmac_params(Token * tline)
                 tail = &t->next;
 		set_text(t, text, tok_strlen(text));
                 t->type = type;
+                nasm_free(text);
             }
             changed = true;
         } else {


### PR DESCRIPTION
Fixes: #3392758
CVE: CVE-2021-33450