### PR TITLE
Fix stack-buffer-overflow in parser.c

### DIFF
--- a/asm/parser.c
+++ b/asm/parser.c
@@ -1175,6 +1175,11 @@ restart_parse:
                  * put the decorator information in the (opflag_t) type field
                  * of previous operand.
                  */
+                if (opnum == 0) {
+                    nasm_nonfatal("decorator without an operand");
+                    goto fail;
+                }
+
                 opnum--; op--;
                 switch (value->value) {
                 case BRC_RN:


### PR DESCRIPTION
A stack-buffer-overflow occurred when a decorator (e.g., rounding or SAE) was encountered without a preceding operand. This caused the operand index to underflow, leading to invalid memory access.

Added a check to ensure `opnum > 0` before decrementing, preventing the underflow and fixing the crash when parsing malformed decorators.

Fixes: #3392931