### PR TITLE
Add missing types in types[] array

### DIFF
--- a/output/outdbg.c
+++ b/output/outdbg.c
@@ -409,8 +409,19 @@ dbg_pragma(const struct pragma *pragma)
 }
 
 static const char * const types[] = {
-    "unknown", "label", "byte", "word", "dword", "float", "qword", "tbyte"
+    "unknown",
+    "label",
+    "byte",
+    "word",
+    "dword",
+    "float",
+    "qword",
+    "tbyte",
+    "oword",
+    "yword",
+    "zword",
 };
+
 static void dbgdbg_init(void)
 {
     fprintf(ofile, "dbg init: debug information enabled\n");


### PR DESCRIPTION
The types[] array in outdbg.c was missing entries for "oword", "yword", and "zword", leading to potential out-of-bounds access.

This patch adds the missing types to prevent the buffer overflow and ensure correct debug information generation.

Fixes: #3392814
CVE: CVE-2022-46456