### PR TITLE
Revisions to documentation

### DIFF
--- a/doc/64bit.src
+++ b/doc/64bit.src
@@ -51,7 +51,7 @@ mode, for 8-, 16-, 32- and 64-bit references, respectively:
 This is consistent with the AMD documentation and most other
 assemblers.  The Intel documentation, however, uses the names
 \c{R8L-R15L} for 8-bit references to the higher registers.  It is
-possible to use those names by definiting them as macros; similarly,
+possible to use those names by defining them as macros; similarly,
 if one wants to use numeric names for the low 8 registers, define them
 as macros.  The standard macro package \c{altreg} (see \k{pkg_altreg})
 can be used for this purpose.
@@ -95,7 +95,7 @@ Note that \c{lea rax,[rel symbol]} is position-independent, whereas
 position-independent code in 64-bit mode.  However, the \c{MOV}
 instruction is able to reference a symbol anywhere in the 64-bit
 address space, whereas \c{LEA} is only able to access a symbol within
-within 2 GB of the instruction itself (see below.)
+within 2 GB of the instruction itself (see below).
 
 The only instructions which take a full \I{64-bit displacement}64-bit
 \e{displacement} is loading or storing, using \c{MOV}, \c{AL}, \c{AX},

--- a/doc/64bit.src
+++ b/doc/64bit.src
@@ -29,9 +29,9 @@ specific size data type is desired, it is probably best to use the
 types defined in the standard C header \c{<inttypes.h>}.
 
 All known 64-bit platforms except some embedded platforms require that
-the stack is 16-byte aligned at the entry to a function.  In order to
-enforce that, the stack pointer (\c{RSP}) needs to be aligned on an
-\c{odd} multiple of 8 bytes before the \c{CALL} instruction.
+the stack is 16-byte aligned at the entry to a function.  Specifically,
+the stack pointer (\c{RSP}) needs to be 16-byte aligned just before the
+\c{CALL} instruction.
 
 In 64-bit mode, the default instruction size is still 32 bits.  When
 loading a value into a 32-bit register (but not an 8- or 16-bit
@@ -182,3 +182,16 @@ Integer and SSE register arguments are counted together, so for the case of
 \c      void foo(long long a, double b, int c)
 
 \c{a} is passed in \c{RCX}, \c{b} in \c{XMM1}, and \c{c} in \c{R8D}.
+
+There is a requirement for functions to allocate a "shadow space" for callees,
+prior to calling them, that is owned by the callee. This is for the callee to
+(optionally) store the arguments that are passed in via registers (e.g. for
+debugging purposes), or in fact any other desired values. This 32-byte shadow
+space must be allocated just before the stack space used for non-register
+arguments (5th and beyond, if any).
+
+Before a function call, 16-byte stack alignment is required.
+
+Regarding shadow space and stack alignment, an exception is made for leaf
+functions, which in Win64 terms means no modification to \c{RSP} at all
+(not just having no function calls).

--- a/doc/directiv.src
+++ b/doc/directiv.src
@@ -71,7 +71,7 @@ necessary.
 
 When the \c{REX} prefix is used, the processor does not know how to
 address the AH, BH, CH or DH (high 8-bit legacy) registers. Instead,
-it is possible to access the the low 8-bits of the SP, BP SI and DI
+it is possible to access the the low 8-bits of the SP, BP, SI and DI
 registers as SPL, BPL, SIL and DIL, respectively; but only when the
 REX prefix is used.
 
@@ -560,7 +560,7 @@ this behaviour:
 
 The standard macros \i\c{__?FLOAT_DAZ?__}, \i\c{__?FLOAT_ROUND?__}, and
 \i\c{__?FLOAT?__} contain the current state, as long as the programmer
-has avoided the use of the brackeded primitive form, (\c{[FLOAT]}).
+has avoided the use of the bracketed primitive form, (\c{[FLOAT]}).
 
 \c{__?FLOAT?__} contains the full set of floating-point settings; this
 value can be saved away and invoked later to restore the setting.

--- a/doc/lang.src
+++ b/doc/lang.src
@@ -452,7 +452,7 @@ Some examples (all producing exactly the same code):
 
 A character string consists of up to eight characters enclosed in
 either single quotes (\c{'...'}), double quotes (\c{"..."}) or
-backquotes (\c{`...`}).  Single or double quotes are equivalent to
+backquotes (\c{`...`}).  Single or double quotes are equivalent in
 NASM (except of course that surrounding the constant with single
 quotes allows double quotes to appear within it and vice versa); the
 contents of those are represented verbatim.  Strings enclosed in
@@ -513,7 +513,7 @@ the sense of character constants understood by the Pentium's
 String constants are character strings used in the context of some
 pseudo-instructions, namely the
 \I\c{DW}\I\c{DD}\I\c{DQ}\I\c{DT}\I\c{DO}\I\c{DY}\i\c{DB} family and
-\i\c{INCBIN} (where it represents a filename.)  They are also used in
+\i\c{INCBIN} (where it represents a filename). They are also used in
 certain preprocessor directives.
 
 A string constant looks like a character constant, only longer. It
@@ -543,7 +543,7 @@ The special operators \i\c{__?utf16?__}, \i\c{__?utf16le?__},
 \i\c{__?utf32be?__} allows definition of Unicode strings.  They take a
 string in UTF-8 format and converts it to UTF-16 or UTF-32,
 respectively.  Unless the \c{be} forms are specified, the output is
-littleendian.
+little endian.
 
 For example:
 

--- a/doc/macropkg.src
+++ b/doc/macropkg.src
@@ -18,7 +18,7 @@ NASM (\c{%ifusable}) or a particular package already loaded (\c{%ifusing}).
 The \c{altreg} standard macro package provides alternate register
 names.  It provides numeric register names for all registers (not just
 \c{R8}-\c{R15}), the Intel-defined aliases \c{R8L}-\c{R15L} for the
-low bytes of register (as opposed to the NASM/AMD standard names
+low bytes of registers (as opposed to the NASM/AMD standard names
 \c{R8B}-\c{R15B}), and the names \c{R0H}-\c{R3H} (by analogy with
 \c{R0L}-\c{R3L}) for \c{AH}, \c{CH}, \c{DH}, and \c{BH}.
 
@@ -35,7 +35,7 @@ See also \k{reg64}.
 
 \H{pkg_smartalign} \i\c{smartalign}\I{align, smart}: Smart \c{ALIGN} Macro
 
-The \c{smartalign} standard macro package provides for an \i\c{ALIGN}
+The \c{smartalign} standard macro package provides an \i\c{ALIGN}
 macro which is more powerful than the default (and
 backwards-compatible) one (see \k{align}).  When the \c{smartalign}
 package is enabled, when \c{ALIGN} is used without a second argument,
@@ -151,7 +151,7 @@ argument had been put in square brackets:
 
 \c      mov eax,[foo]               ; memory reference
 \c      mov eax,dword ptr foo       ; memory reference
-\c      mov eax,dowrd ptr flat:foo  ; memory reference
+\c      mov eax,dword ptr flat:foo  ; memory reference
 \c      mov eax,offset foo          ; address
 \c      mov eax,foo                 ; address (ambiguous syntax in MASM)
 

--- a/doc/outfmt.src
+++ b/doc/outfmt.src
@@ -807,65 +807,61 @@ operand only:
 
 \S{win64seh} \c{win64}: Structured Exception Handling
 
-Structured exception handing in Win64 is completely different matter
-from Win32. Upon exception program counter value is noted, and
-linker-generated table comprising start and end addresses of all the
-functions [in given executable module] is traversed and compared to the
-saved program counter. Thus so called \c{UNWIND_INFO} structure is
-identified. If it's not found, then offending subroutine is assumed to
-be "leaf" and just mentioned lookup procedure is attempted for its
-caller. In Win64, a leaf function is a function that does not call any
-other functions \e{nor} modifies any Win64 non-volatile registers,
+Structured exception handing in Win64 is completely different compared
+to Win32. When an exception occurs, the program counter is noted, and a
+linker-generated table containing start and end addresses of all the
+functions (in a given executable module) is traversed and compared to
+the saved program counter. This is used to identify the corresponding
+\c{UNWIND_INFO} structure. If missing, then the offending subroutine is
+assumed to be "leaf" and this lookup procedure is instead attempted for
+its caller. In Win64, a leaf function is a function that does not call
+any other functions \e{nor} modifies any Win64 non-volatile registers,
 including the stack pointer. The latter ensures that it's possible to
 identify a leaf function's caller by simply pulling the value from the
 top of the stack.
 
-While majority of subroutines written in assembler are not calling any
-other function, requirement for non-volatile registers' immutability
-leaves developer with not more than 7 registers and no stack frame,
-which is not necessarily what [s]he counted with. Customarily one would
-meet the requirement by saving non-volatile registers on stack and
-restoring them upon return, so what can go wrong? If [and only if] an
-exception is raised at run-time and no \c{UNWIND_INFO} structure is
-associated with such "leaf" function, the stack unwind procedure will
-expect to find caller's return address on the top of stack immediately
-followed by its frame. Given that developer pushed caller's
-non-volatile registers on stack, would the value on top point at some
-code segment or even addressable space? Well, developer can attempt
-copying caller's return address to the top of stack and this would
-actually work in some very specific circumstances. But unless developer
-can guarantee that these circumstances are always met, it's more
-appropriate to assume worst case scenario, i.e. stack unwind procedure
-going berserk. Relevant question is what happens then? Application is
-abruptly terminated without any notification whatsoever. Just like in
-Win32 case, one can argue that system could at least have logged
-"unwind procedure went berserk in x.exe at address n" in event log, but
-no, no trace of failure is left.
+While the majority of subroutines written in assembler are not calling
+any other functions, they may not qualify as "leaf" functions in the
+Win64 sense. The requirement for non-volatile registers to be
+unchanged leaves the developer with not more than 7 registers and no
+stack frame, which is not necessarily what they counted on.
+Customarily one would meet this requirement by saving non-volatile
+registers on stack and restoring them upon return. However, if (and
+only if) an exception is raised at run-time and no \c{UNWIND_INFO}
+structure is associated with such a "leaf" function, the stack unwind
+procedure will expect to find the caller's return address on the top of
+the stack immediately followed by its frame. Given that the developer
+pushed the caller's non-volatile registers onto the stack, the value
+on top will no longer point to the right place. The developer can
+attempt to copy the caller's return address to the top of stack, which
+would work in some very specific circumstances. But unless the
+developer can guarantee that these circumstances are always met, it's
+more appropriate to assume the worst, i.e. the stack unwind procedure
+goes berserk, abruptly terminating without any notification whatsoever
+(just like in the the Win32 case).
 
-Now, when we understand significance of the \c{UNWIND_INFO} structure,
-let's discuss what's in it and/or how it's processed. First of all it
-is checked for presence of reference to custom language-specific
-exception handler. If there is one, then it's invoked. Depending on the
-return value, execution flow is resumed (exception is said to be
-"handled"), \e{or} rest of \c{UNWIND_INFO} structure is processed as
-following. Beside optional reference to custom handler, it carries
-information about current callee's stack frame and where non-volatile
-registers are saved. Information is detailed enough to be able to
-reconstruct contents of caller's non-volatile registers upon call to
-current callee. And so caller's context is reconstructed, and then
-unwind procedure is repeated, i.e. another \c{UNWIND_INFO} structure is
-associated, this time, with caller's instruction pointer, which is then
-checked for presence of reference to language-specific handler, etc.
-The procedure is recursively repeated till exception is handled. As
-last resort system "handles" it by generating memory core dump and
-terminating the application.
+Now that we understand significance of the \c{UNWIND_INFO} structure,
+let us discuss what is in it and how it is processed. First, it is
+checked for the presence of a reference to a custom language-specific
+exception handler. If there is one, then it is invoked. Depending on
+the return value, execution flow is resumed (exception is said to be
+"handled"), \e{or} the rest of the \c{UNWIND_INFO} structure is
+processed as follows. Aside from an optional reference to a custom
+handler, it carries information about the current callee's stack frame
+and where non-volatile registers are saved. The information is detailed
+enough to be able to reconstruct the contents of the caller's
+non-volatile registers on entry to the current callee. And so the
+caller's context is reconstructed, at which point the unwind procedure
+is repeated, using the \c{UNWIND_INFO} structure associated with the
+caller's instruction pointer. The procedure is repeated recursively
+until the exception is handled. As a last resort, the system "handles"
+it by generating a memory dump and terminating the application.
 
-As for the moment of this writing NASM unfortunately does not
-facilitate generation of above mentioned detailed information about
-stack frame layout. But as of version 2.03 it implements building
-blocks for generating structures involved in stack unwinding. As
-simplest example, here is how to deploy custom exception handler for
-leaf function:
+As of this writing, NASM unfortunately does not facilitate generation
+of above mentioned detailed information about stack frame layout. But
+as of version 2.03, it implements building blocks for generating
+structures involved in stack unwinding. Here is a simple example
+showing how to deploy a custom exception handler for a leaf function:
 
 \c default rel
 \c section .text
@@ -900,36 +896,36 @@ leaf function:
 \c section .drectve info
 \c         db      '/defaultlib:user32.lib /defaultlib:msvcrt.lib '
 
-What you see in \c{.pdata} section is element of the "table comprising
-start and end addresses of function" along with reference to associated
-\c{UNWIND_INFO} structure. And what you see in \c{.xdata} section is
-\c{UNWIND_INFO} structure describing function with no frame, but with
-designated exception handler. References are \e{required} to be
-image-relative (which is the real reason for implementing \c{wrt
-..imagebase} operator). It should be noted that \c{rdata align=n}, as
-well as \c{wrt ..imagebase}, are optional in these two segments'
-contexts, i.e. can be omitted. Latter means that \e{all} 32-bit
-references, not only above listed required ones, placed into these two
-segments turn out image-relative. Why is it important to understand?
-Developer is allowed to append handler-specific data to \c{UNWIND_INFO}
-structure, and if [s]he adds a 32-bit reference, then [s]he will have
-to remember to adjust its value to obtain the real pointer.
+What you see is that the \c{.pdata} section contains a single-element
+table, containing function start and end addresses, along with references
+to associated \c{UNWIND_INFO} structures (only one in this case). The
+\c{.xdata} section contains the referenced \c{UNWIND_INFO} structure,
+describing a function with no frame, but with a designated exception handler.
+These references are \e{required} to be image-relative, which is the real
+reason for implementing the \c{wrt ..imagebase} operator). It should be
+noted that \c{rdata align=n}, as well as \c{wrt ..imagebase}, are actually
+optional in the context of these two segments (they apply even when omitted);
+\e{all} 32-bit references placed into these two segments will be image-relative.
+This is important to understand, as the developer is allowed to append
+handler-specific data to the \c{UNWIND_INFO} structure, and any 32-bit
+references that are added may require adjustment to obtain the real pointer.
 
-As already mentioned, in Win64 terms leaf function is one that does not
-call any other function \e{nor} modifies any non-volatile register,
-including stack pointer. But it's not uncommon that assembler
-programmer plans to utilize every single register and sometimes even
-have variable stack frame. Is there anything one can do with bare
-building blocks? I.e. besides manually composing fully-fledged
-\c{UNWIND_INFO} structure, which would surely be considered
-error-prone? Yes, there is. Recall that exception handler is called
-first, before stack layout is analyzed. As it turned out, it's
-perfectly possible to manipulate current callee's context in custom
-handler in manner that permits further stack unwinding. General idea is
-that handler would not actually "handle" the exception, but instead
-restore callee's context, as it was at its entry point and thus mimic
-leaf function. In other words, handler would simply undertake part of
-unwinding procedure. Consider following example:
+As already mentioned, in Win64 terms, a leaf function is one that neither
+calls any other function \e{nor} modifies any non-volatile registers,
+including the stack pointer. But it is not uncommon for the programmer
+to intend to utilize every single register and sometimes even have a
+variable stack frame, requiring a more complicated \c{UNWIND_INFO} structure
+than in the example above. Is there anything one can do with these simpler
+building blocks, and avoid manually composing fully-fledged \c{UNWIND_INFO}
+structures, which would surely be considered error-prone? Yes, there is.
+Recall that an exception handler is called first, before the stack layout
+is analyzed. As it turns out, it is perfectly possible to manipulate
+current callee's context in a custom handler in a manner that permits
+further stack unwinding. The general idea is that handler would not
+actually "handle" the exception, but instead restore the callee's context
+(restore to state at entry point) and thus mimic a Win64 leaf function.
+In other words, the handler would effectively undertake part of the
+unwinding procedure. Consider the following example:
 
 \c function:
 \c         mov     rax,rsp         ; copy rsp to volatile register
@@ -951,11 +947,11 @@ unwinding procedure. Consider following example:
 \c         mov     rsp,r11         ; destroy frame
 \c         ret
 
-The keyword is that up to \c{magic_point} original \c{rsp} value
-remains in chosen volatile register and no non-volatile register,
-except for \c{rsp}, is modified. While past \c{magic_point} \c{rsp}
-remains constant till the very end of the \c{function}. In this case
-custom language-specific exception handler would look like this:
+The key is that until \c{magic_point}, the original \c{rsp} value
+remains in the chosen volatile register, and no non-volatile register
+except for \c{rsp} is modified. After \c{magic_point}, \c{rsp} remains
+constant till the very end of the \c{function}. In this case a custom
+language-specific exception handler would look like this:
 
 \c EXCEPTION_DISPOSITION handler (EXCEPTION_RECORD *rec,ULONG64 frame,
 \c         CONTEXT *context,DISPATCHER_CONTEXT *disp)
@@ -977,9 +973,9 @@ custom language-specific exception handler would look like this:
 \c     return ExceptionContinueSearch;
 \c }
 
-As custom handler mimics leaf function, corresponding \c{UNWIND_INFO}
-structure does not have to contain any information about stack frame
-and its layout.
+As this custom handler allows the example function to mimic a Win64 leaf
+function, the corresponding \c{UNWIND_INFO} structure does not need to
+contain any information about the stack frame and its layout.
 
 \H{cofffmt} \i\c{coff}: \i{Common Object File Format}
 

--- a/doc/outfmt.src
+++ b/doc/outfmt.src
@@ -109,8 +109,9 @@ with \i\c{vstart=}.
 start address.
 
 \b Arguments to \c{org}, \c{start}, \c{vstart}, and \c{align=} are
-critical expressions. See \k{crit}. E.g. \c{align=(1 << ALIGN_SHIFT)}
-- \c{ALIGN_SHIFT} must be defined before it is used here.
+critical expressions. See \k{crit}. For example, in the case of
+\c{align=(1 << ALIGN_SHIFT)}, \c{ALIGN_SHIFT} must be defined before
+it is used here.
 
 \b Any code which comes before an explicit \c{SECTION} directive
 is directed by default into the \c{.text} section.
@@ -179,7 +180,7 @@ for historical reasons) is the one produced by \i{MASM} and
 
 \c{obj} provides a default output file-name extension of \c{.obj}.
 
-\c{obj} is not exclusively a 16-bit format, though: NASM has full
+\c{obj} is not exclusively a 16-bit format, though; NASM has full
 support for the 32-bit extensions to the format. In particular,
 32-bit \c{obj} format files are used by \i{Borland's Win32
 compilers}, instead of using Microsoft's newer \i\c{win32} object
@@ -631,42 +632,42 @@ Any other section name is treated by default like \c{.text}.
 
 \S{win32safeseh} \c{win32}: Safe Structured Exception Handling
 
-Among other improvements in Windows XP SP2 and Windows Server 2003
-Microsoft has introduced concept of "safe structured exception
-handling." General idea is to collect handlers' entry points in
-designated read-only table and have alleged entry point verified
-against this table prior exception control is passed to the handler. In
-order for an executable module to be equipped with such "safe exception
-handler table," all object modules on linker command line has to comply
-with certain criteria. If one single module among them does not, then
-the table in question is omitted and above mentioned run-time checks
-will not be performed for application in question. Table omission is by
-default silent and therefore can be easily overlooked. One can instruct
-linker to refuse to produce binary without such table by passing
+Among other improvements in Windows XP SP2 and Windows Server 2003,
+Microsoft has introduced the concept of "safe structured exception
+handling." The general idea is to collect handlers' entry points
+in a designated read-only table and have SEH entry points verified
+against this table before exception control is passed to the
+corresponding handler. In order for an executable module to be
+equipped with this read-only table, all object modules on linker
+command line have to comply with certain criteria. If even a single
+module among them does not, then the table in question is omitted
+and above mentioned run-time checks will not be performed for the
+application in question. Table omission is silent by default and
+therefore can be easily missed. One can instruct the linker to
+refuse to produce binary without such table by passing the
 \c{/safeseh} command line option.
 
-Without regard to this run-time check merits it's natural to expect
+Without regard to this run-time check, it's natural to expect
 NASM to be capable of generating modules suitable for \c{/safeseh}
-linking. From developer's viewpoint the problem is two-fold:
+linking. From the developer's viewpoint the problem is two-fold:
 
 \b how to adapt modules not deploying exception handlers of their own;
 
 \b how to adapt/develop modules utilizing custom exception handling;
 
-Former can be easily achieved with any NASM version by adding following
-line to source code:
+The former can be easily achieved with any NASM version by adding the
+following line to the source code:
 
 \c $@feat.00 equ 1
 
-As of version 2.03 NASM adds this absolute symbol automatically. If
-it's not already present to be precise. I.e. if for whatever reason
-developer would choose to assign another value in source file, it would
-still be perfectly possible.
+As of version 2.03 NASM adds this absolute symbol automatically, if
+it is not already present (in which case the developer can choose to
+assign another value, if desired, for whatever reason).
 
-Registering custom exception handler on the other hand requires certain
-"magic." As of version 2.03 additional directive is implemented,
-\c{safeseh}, which instructs the assembler to produce appropriately
-formatted input data for above mentioned "safe exception handler
+Registering a custom exception handler on the other hand requires
+certain "magic." As of version 2.03, an additional \c{safeseh} directive
+is implemented, which instructs the assembler to produce appropriately
+formatted input data for the above-mentioned "safe exception handler
 table." Its typical use would be:
 
 \c section .text
@@ -699,19 +700,18 @@ table." Its typical use would be:
 \c section .drectve info
 \c         db      '/defaultlib:user32.lib /defaultlib:msvcrt.lib '
 
-As you might imagine, it's perfectly possible to produce .exe binary
-with "safe exception handler table" and yet engage unregistered
-exception handler. Indeed, handler is engaged by simply manipulating
-\c{[fs:0]} location at run-time, something linker has no power over,
-run-time that is. It should be explicitly mentioned that such failure
-to register handler's entry point with \c{safeseh} directive has
-undesired side effect at run-time. If exception is raised and
-unregistered handler is to be executed, the application is abruptly
-terminated without any notification whatsoever. One can argue that
-system could  at least have logged some kind "non-safe exception
-handler in x.exe at address n" message in event log, but no, literally
-no notification is provided and user is left with no clue on what
-caused application failure.
+As you might imagine, it's perfectly possible to produce an .exe binary
+with the "safe exception handler table" and yet invoke an unregistered
+exception handler. A handler is invoked by manipulating \c{[fs:0]}
+at run-time, something the linker has no power over. It is therefore
+important to note that such failure to register a handler's entry point
+with the \c{safeseh} directive will have undesired side effects at
+run-time. If an exception is raised and an unregistered handler is to be
+executed, the application is abruptly terminated without any notification
+whatsoever. One can argue that the system should at least log some kind
+of "non-safe exception handler in x.exe at address n" message in the
+event log, but unfortunately the user is left without any clue as to
+what might have caused the crash.
 
 Finally, all mentions of linker in this paragraph refer to Microsoft
 linker version 7.x and later. Presence of \c{@feat.00} symbol and input
@@ -749,7 +749,7 @@ references. Consider a switch dispatch table:
 \c         ...
 
 Even a novice Win64 assembler programmer will soon realize that the code
-is not 64-bit savvy. Most notably linker will refuse to link it with
+is not 64-bit savvy. Most notably the linker will refuse to link it, showing:
 
 \c 'ADDR32' relocation to '.text' invalid without /LARGEADDRESSAWARE:NO
 
@@ -758,15 +758,15 @@ So [s]he will have to split jmp instruction as following:
 \c         lea     rbx,[rel dsptch]
 \c         jmp     qword [rbx+rax*8]
 
-What happens behind the scene is that effective address in \c{lea} is
-encoded relative to instruction pointer, or in perfectly
+What happens behind the scenes is that the effective address in \c{lea}
+is encoded relative to instruction pointer, in a perfectly
 position-independent manner. But this is only part of the problem!
-Trouble is that in .dll context \c{caseN} relocations will make their
-way to the final module and might have to be adjusted at .dll load
-time. To be specific when it can't be loaded at preferred address. And
-when this occurs, pages with such relocations will be rendered private
-to current process, which kind of undermines the idea of sharing .dll.
-But no worry, it's trivial to fix:
+The issue is that in a .dll context, the \c{caseN} relocations will make
+their way to the final module and might have to be adjusted at .dll load
+time (specifically, when it can't be loaded at the preferred address).
+When this occurs, pages with such relocations will be rendered private
+to current process, which kind of undermines the idea of a shared .dll.
+But not to worry, it's trivial to fix:
 
 \c         lea     rbx,[rel dsptch]
 \c         add     rbx,[rbx+rax*8]
@@ -777,11 +777,11 @@ But no worry, it's trivial to fix:
 \c         ...
 
 NASM version 2.03 and later provides another alternative, \c{wrt
-..imagebase} operator, which returns offset from base address of the
-current image, be it .exe or .dll module, therefore the name. For those
-acquainted with PE-COFF format base address denotes start of
-\c{IMAGE_DOS_HEADER} structure. Here is how to implement switch with
-these image-relative references:
+..imagebase} operator, which returns an offset from base address of the
+current image, be it .exe or .dll module, hence the name. For those
+acquainted with PE-COFF format, this base address denotes the start of
+the \c{IMAGE_DOS_HEADER} structure. Here is how to implement a switch
+statement with these image-relative references:
 
 \c         lea     rbx,[rel dsptch]
 \c         mov     eax,[rbx+rax*4]
@@ -792,10 +792,10 @@ these image-relative references:
 \c dsptch: dd      case0 wrt ..imagebase
 \c         dd      case1 wrt ..imagebase
 
-One can argue that the operator is redundant. Indeed,  snippet before
-last works just fine with any NASM version and is not even Windows
-specific... The real reason for implementing \c{wrt ..imagebase} will
-become apparent in next paragraph.
+That said, the snippet before last works just fine with any NASM version
+and is not even Windows specific, which makes this operator unnecessary
+in this case. The real reason for the \c{wrt ..imagebase} operator will
+become apparent in the next section.
 
 It should be noted that \c{wrt ..imagebase} is defined as 32-bit
 operand only:
@@ -814,10 +814,10 @@ functions [in given executable module] is traversed and compared to the
 saved program counter. Thus so called \c{UNWIND_INFO} structure is
 identified. If it's not found, then offending subroutine is assumed to
 be "leaf" and just mentioned lookup procedure is attempted for its
-caller. In Win64 leaf function is such function that does not call any
-other function \e{nor} modifies any Win64 non-volatile registers,
-including stack pointer. The latter ensures that it's possible to
-identify leaf function's caller by simply pulling the value from the
+caller. In Win64, a leaf function is a function that does not call any
+other functions \e{nor} modifies any Win64 non-volatile registers,
+including the stack pointer. The latter ensures that it's possible to
+identify a leaf function's caller by simply pulling the value from the
 top of the stack.
 
 While majority of subroutines written in assembler are not calling any
@@ -1187,8 +1187,8 @@ override that.
 
 \b \i\c{merge} indicates that duplicate data elements in this section
 should be merged with data elements from other object files. Data
-elements can be either fixed-sized objects or null-terminatedstrings
-(with the \c{strings} attribute.) A size specifier is required unless
+elements can be either fixed-sized objects or null-terminated strings
+(with the \c{strings} attribute). A size specifier is required unless
 \c{strings} is specified, in which case the size defaults to \c{byte}.
 
 \b \i\c{tls} defines the section to be one which contains

--- a/doc/preproc.src
+++ b/doc/preproc.src
@@ -612,8 +612,8 @@ It's often useful to be able to handle strings in macros. NASM
 supports a few simple string handling macro operators from which
 more complex operations can be constructed.
 
-All the string operators define or redefine a value (either a string
-or a numeric value) to a single-line macro.  When producing a string
+All the string operators define or redefine a single-line macro to some
+value (either a string or a numeric value).  When producing a string
 value, it may change the style of quoting of the input string or
 strings, and possibly use \c{\\}-escapes inside \c{`}-quoted strings.
 
@@ -680,7 +680,7 @@ than the description:
 As with \c{%strlen} (see \k{strlen}), the first parameter is the
 single-line macro to be created and the second is the string. The
 third parameter specifies the first character to be selected, and the
-optional fourth parameter preceded by comma) is the length.  Note
+optional fourth parameter (preceded by comma) is the length.  Note
 that the first index is 1, not 0 and the last index is equal to the
 value that \c{%strlen} would assign given the same string. Index
 values out of range result in an empty string.  A negative length
@@ -1411,7 +1411,7 @@ iterated through in reverse order.
 \S{concat} \i{Concatenating Macro Parameters}
 
 NASM can concatenate macro parameters and macro indirection constructs
-on to other text surrounding them. This allows you to declare a family
+with other surrounding text. This allows you to declare a family
 of symbols, for example, in a macro definition. If, for example, you
 wanted to generate a table of key codes along with offsets into the
 table, you could code something like
@@ -2065,7 +2065,7 @@ This pushes a new context called \c{foobar} on the stack. You can have
 several contexts on the stack with the same name: they can still be
 distinguished.  If no name is given, the context is unnamed (this is
 normally used when both the \c{%push} and the \c{%pop} are inside a
-single macro definition.)
+single macro definition).
 
 The directive \c{%pop}, taking one optional argument, removes the top
 context from the context stack and destroys it, along with any
@@ -2237,7 +2237,7 @@ implement a block IF statement as a set of macros.
 This code is more robust than the \c{REPEAT} and \c{UNTIL} macros
 given in \k{ctxlocal}, because it uses conditional assembly to check
 that the macros are issued in the right order (for example, not
-calling \c{endif} before \c{if}) and issues a \c{%error} if they're
+calling \c{endif} before \c{if}) and issues an \c{%error} if they're
 not.
 
 In addition, the \c{endif} macro has to be able to cope with the two

--- a/doc/preproc.src
+++ b/doc/preproc.src
@@ -2040,8 +2040,8 @@ existence and inclusion of a specific standard macro package, see
 Having labels that are local to a macro definition is sometimes not
 quite powerful enough: sometimes you want to be able to share labels
 between several macro calls. An example might be a \c{REPEAT} ...
-\c{UNTIL} loop, in which the expansion of the \c{REPEAT} macro
-would need to be able to refer to a label which the \c{UNTIL} macro
+\c{UNTIL} loop, in which the expansion of the \c{UNTIL} macro
+would need to be able to refer to a label which the \c{REPEAT} macro
 had defined. However, for such a macro you would also want to be
 able to nest these loops.
 
@@ -2097,9 +2097,9 @@ above could be implemented by means of:
 
 and invoked by means of, for example,
 
-\c         mov     cx,string
+\c         mov     di,string
 \c         repeat
-\c         add     cx,3
+\c         add     di,3
 \c         scasb
 \c         until   e
 

--- a/doc/running.src
+++ b/doc/running.src
@@ -526,17 +526,17 @@ accepted for this option starting in NASM version 2.11.05.
 
 \S{opt-pfix} The \i\c{--(g|l)prefix}, \i\c{--(g|l)postfix} Options.
 
-The \c{--(g)prefix} options prepend the given argument
+The \c{--gprefix} option prepends the given argument
 to all \c{extern}, \c{common}, \c{static}, and \c{global} symbols, and the
 \c{--lprefix} option prepends to all other symbols. Similarly,
-\c{--(g)postfix} and \c{--lpostfix} options append
-the argument in the exactly same way as the \c{--xxprefix} options does.
+\c{--gpostfix} and \c{--lpostfix} options append
+the argument, in a manner similar to the \c{--(g|l)prefix} options.
 
 Running this:
 
 \c nasm -f macho --gprefix _
 
-is equivalent to place the directive with \c{%pragma macho gprefix _}
+is equivalent to placing the directive \c{%pragma macho gprefix _}
 at the start of the file (\k{mangling}). It will prepend the underscore
 to all global and external variables, as C requires it in some, but not all,
 system calling conventions.
@@ -585,7 +585,7 @@ before returning to the top-level input. Default is 100000.
 \b\c{--limit-rep}: Maximum number of allowed preprocessor loop, defined
 under \c{%rep}. Default is 1000000.
 
-\b\c{--limit-eval}: This number sets the boundary condition of allowed
+\b\c{--limit-eval}: This number sets the maximum allowed
 expression length. Default is 8192 on most systems.
 
 \b\c{--limit-lines}: Total number of source lines allowed to be


### PR DESCRIPTION
I read through your documentation, and found some issues.
Lots of them were minor misspellings or grammatical issues, but there were some parts that I found deeply unclear in their meaning, and even parts that were just wrong (specifically the claim that the popular 64-bit system ABIs expect 16-byte stack alignment after the call, rather than before - AFAICT, this is exactly the opposite of what the specs say).

I have done my best to fix these issues, and have tried to split it into commits that might make it easier to review.
Thanks for the project, hope this helps!