### PR TITLE
Fix typo "lime" -> "line"

### DIFF
--- a/asm/nasm.c
+++ b/asm/nasm.c
@@ -185,7 +185,7 @@ static const struct limit_info limit_info[LIMIT_MAX+1] = {
     { "passes", "total number of passes", LIMIT_MAX_VAL },
     { "stalled-passes", "number of passes without forward progress", 1000 },
     { "macro-levels", "levels of macro expansion", 10000 },
-    { "macro-tokens", "tokens processed during single-lime macro expansion", 10000000 },
+    { "macro-tokens", "tokens processed during single-line macro expansion", 10000000 },
     { "mmacros", "multi-line macros before final return", 100000 },
     { "rep", "%rep count", 1000000 },
     { "eval", "expression evaluation descent", 8192 },


### PR DESCRIPTION
Noticed it while reading the help text.