### PR TITLE
AVX512BF16 fix, AVX512BF16 test files

### DIFF
--- a/test/avx512bf16-64.asm
+++ b/test/avx512bf16-64.asm
@@ -1,0 +1,108 @@
+BITS 64
+	vcvtne2ps2bf16 xmm1, xmm2, xmm3
+	vcvtne2ps2bf16 ymm1, ymm2, ymm3
+	vcvtne2ps2bf16 zmm1, zmm2, zmm3
+
+	vcvtneps2bf16 xmm1, xmm2
+	vcvtneps2bf16 xmm1, ymm2
+	vcvtneps2bf16 ymm1, zmm2
+
+	vdpbf16ps xmm1, xmm2, xmm3
+	vdpbf16ps ymm1, ymm2, ymm3
+	vdpbf16ps zmm1, zmm2, zmm3
+
+	vcvtne2ps2bf16 xmm1, xmm2, [rax]
+	vcvtne2ps2bf16 ymm1, ymm2, [rcx+1]
+	vcvtne2ps2bf16 zmm1, zmm2, [2*rdx+64]
+
+	vcvtneps2bf16 xmm1, oword [rax]
+	vcvtneps2bf16 xmm1, yword [rcx+1]
+	vcvtneps2bf16 ymm1, [2*rdx+64]
+
+	vdpbf16ps xmm1, xmm2, [rax]
+	vdpbf16ps ymm1, ymm2, [rcx+1]
+	vdpbf16ps zmm1, zmm2, [2*rdx+64]
+
+	vcvtne2ps2bf16 xmm1, xmm2, [rax]{1to4}
+	vcvtne2ps2bf16 ymm1, ymm2, [rcx+1]{1to8}
+	vcvtne2ps2bf16 zmm1, zmm2, [2*rdx+4]{1to16}
+
+	vcvtneps2bf16 xmm1, [rax]{1to4}
+	vcvtneps2bf16 xmm1, [rcx+1]{1to8}
+	vcvtneps2bf16 ymm1, [2*rdx+4]{1to16}
+
+	vdpbf16ps xmm1, xmm2, [rax]{1to4}
+	vdpbf16ps ymm1, ymm2, [rcx+1]{1to8}
+	vdpbf16ps zmm1, zmm2, [2*rdx+4]{1to16}
+
+	vcvtne2ps2bf16 xmm1 {k1}, xmm2, xmm3
+	vcvtne2ps2bf16 ymm1 {k1}, ymm2, ymm3
+	vcvtne2ps2bf16 zmm1 {k1}, zmm2, zmm3
+
+	vcvtneps2bf16 xmm1 {k1}, xmm2
+	vcvtneps2bf16 xmm1 {k1}, ymm2
+	vcvtneps2bf16 ymm1 {k1}, zmm2
+
+	vdpbf16ps xmm1 {k1}, xmm2, xmm3
+	vdpbf16ps ymm1 {k1}, ymm2, ymm3
+	vdpbf16ps zmm1 {k1}, zmm2, zmm3
+
+	vcvtne2ps2bf16 xmm1 {k1}, xmm2, [rax]
+	vcvtne2ps2bf16 ymm1 {k1}, ymm2, [rcx+1]
+	vcvtne2ps2bf16 zmm1 {k1}, zmm2, [2*rdx+64]
+
+	vcvtneps2bf16 xmm1 {k1}, oword [rax]
+	vcvtneps2bf16 xmm1 {k1}, yword [rcx+1]
+	vcvtneps2bf16 ymm1 {k1}, [2*rdx+64]
+
+	vdpbf16ps xmm1 {k1}, xmm2, [rax]
+	vdpbf16ps ymm1 {k1}, ymm2, [rcx+1]
+	vdpbf16ps zmm1 {k1}, zmm2, [2*rdx+64]
+
+	vcvtne2ps2bf16 xmm1 {k1}, xmm2, [rax]{1to4}
+	vcvtne2ps2bf16 ymm1 {k1}, ymm2, [rcx+1]{1to8}
+	vcvtne2ps2bf16 zmm1 {k1}, zmm2, [2*rdx+4]{1to16}
+
+	vcvtneps2bf16 xmm1 {k1}, [rax]{1to4}
+	vcvtneps2bf16 xmm1 {k1}, [rcx+1]{1to8}
+	vcvtneps2bf16 ymm1 {k1}, [2*rdx+4]{1to16}
+
+	vdpbf16ps xmm1 {k1}, xmm2, [rax]{1to4}
+	vdpbf16ps ymm1 {k1}, ymm2, [rcx+1]{1to8}
+	vdpbf16ps zmm1 {k1}, zmm2, [2*rdx+4]{1to16}
+
+	vcvtne2ps2bf16 xmm1 {k1}{z}, xmm2, xmm3
+	vcvtne2ps2bf16 ymm1 {k1}{z}, ymm2, ymm3
+	vcvtne2ps2bf16 zmm1 {k1}{z}, zmm2, zmm3
+
+	vcvtneps2bf16 xmm1 {k1}{z}, xmm2
+	vcvtneps2bf16 xmm1 {k1}{z}, ymm2
+	vcvtneps2bf16 ymm1 {k1}{z}, zmm2
+
+	vdpbf16ps xmm1 {k1}{z}, xmm2, xmm3
+	vdpbf16ps ymm1 {k1}{z}, ymm2, ymm3
+	vdpbf16ps zmm1 {k1}{z}, zmm2, zmm3
+
+	vcvtne2ps2bf16 xmm1 {k1}{z}, xmm2, [rax]
+	vcvtne2ps2bf16 ymm1 {k1}{z}, ymm2, [rcx+1]
+	vcvtne2ps2bf16 zmm1 {k1}{z}, zmm2, [2*rdx+64]
+
+	vcvtneps2bf16 xmm1 {k1}{z}, oword [rax]
+	vcvtneps2bf16 xmm1 {k1}{z}, yword [rcx+1]
+	vcvtneps2bf16 ymm1 {k1}{z}, [2*rax+64]
+
+	vdpbf16ps xmm1 {k1}{z}, xmm2, [rax]
+	vdpbf16ps ymm1 {k1}{z}, ymm2, [rcx+1]
+	vdpbf16ps zmm1 {k1}{z}, zmm2, [2*rdx+64]
+
+	vcvtne2ps2bf16 xmm1 {k1}{z}, xmm2, [rax]{1to4}
+	vcvtne2ps2bf16 ymm1 {k1}{z}, ymm2, [rcx+1]{1to8}
+	vcvtne2ps2bf16 zmm1 {k1}{z}, zmm2, [2*rdx+4]{1to16}
+
+	vcvtneps2bf16 xmm1 {k1}{z}, [rax]{1to4}
+	vcvtneps2bf16 xmm1 {k1}{z}, [rcx+1]{1to8}
+	vcvtneps2bf16 ymm1 {k1}{z}, [2*rdx+4]{1to16}
+
+	vdpbf16ps xmm1 {k1}{z}, xmm2, [rax]{1to4}
+	vdpbf16ps ymm1 {k1}{z}, ymm2, [rcx+1]{1to8}
+	vdpbf16ps zmm1 {k1}{z}, zmm2, [2*rdx+4]{1to16}

--- a/test/avx512bf16.asm
+++ b/test/avx512bf16.asm
@@ -1,0 +1,108 @@
+BITS 32
+	vcvtne2ps2bf16 xmm1, xmm2, xmm3
+	vcvtne2ps2bf16 ymm1, ymm2, ymm3
+	vcvtne2ps2bf16 zmm1, zmm2, zmm3
+
+	vcvtneps2bf16 xmm1, xmm2
+	vcvtneps2bf16 xmm1, ymm2
+	vcvtneps2bf16 ymm1, zmm2
+
+	vdpbf16ps xmm1, xmm2, xmm3
+	vdpbf16ps ymm1, ymm2, ymm3
+	vdpbf16ps zmm1, zmm2, zmm3
+
+	vcvtne2ps2bf16 xmm1, xmm2, [eax]
+	vcvtne2ps2bf16 ymm1, ymm2, [ecx+1]
+	vcvtne2ps2bf16 zmm1, zmm2, [2*edx+64]
+
+	vcvtneps2bf16 xmm1, oword [eax]
+	vcvtneps2bf16 xmm1, yword [ecx+1]
+	vcvtneps2bf16 ymm1, [2*edx+64]
+
+	vdpbf16ps xmm1, xmm2, [eax]
+	vdpbf16ps ymm1, ymm2, [ecx+1]
+	vdpbf16ps zmm1, zmm2, [2*edx+64]
+
+	vcvtne2ps2bf16 xmm1, xmm2, [eax]{1to4}
+	vcvtne2ps2bf16 ymm1, ymm2, [ecx+1]{1to8}
+	vcvtne2ps2bf16 zmm1, zmm2, [2*edx+4]{1to16}
+
+	vcvtneps2bf16 xmm1, [eax]{1to4}
+	vcvtneps2bf16 xmm1, [ecx+1]{1to8}
+	vcvtneps2bf16 ymm1, [2*edx+4]{1to16}
+
+	vdpbf16ps xmm1, xmm2, [eax]{1to4}
+	vdpbf16ps ymm1, ymm2, [ecx+1]{1to8}
+	vdpbf16ps zmm1, zmm2, [2*edx+4]{1to16}
+
+	vcvtne2ps2bf16 xmm1 {k1}, xmm2, xmm3
+	vcvtne2ps2bf16 ymm1 {k1}, ymm2, ymm3
+	vcvtne2ps2bf16 zmm1 {k1}, zmm2, zmm3
+
+	vcvtneps2bf16 xmm1 {k1}, xmm2
+	vcvtneps2bf16 xmm1 {k1}, ymm2
+	vcvtneps2bf16 ymm1 {k1}, zmm2
+
+	vdpbf16ps xmm1 {k1}, xmm2, xmm3
+	vdpbf16ps ymm1 {k1}, ymm2, ymm3
+	vdpbf16ps zmm1 {k1}, zmm2, zmm3
+
+	vcvtne2ps2bf16 xmm1 {k1}, xmm2, [eax]
+	vcvtne2ps2bf16 ymm1 {k1}, ymm2, [ecx+1]
+	vcvtne2ps2bf16 zmm1 {k1}, zmm2, [2*edx+64]
+
+	vcvtneps2bf16 xmm1 {k1}, oword [eax]
+	vcvtneps2bf16 xmm1 {k1}, yword [ecx+1]
+	vcvtneps2bf16 ymm1 {k1}, [2*edx+64]
+
+	vdpbf16ps xmm1 {k1}, xmm2, [eax]
+	vdpbf16ps ymm1 {k1}, ymm2, [ecx+1]
+	vdpbf16ps zmm1 {k1}, zmm2, [2*edx+64]
+
+	vcvtne2ps2bf16 xmm1 {k1}, xmm2, [eax]{1to4}
+	vcvtne2ps2bf16 ymm1 {k1}, ymm2, [ecx+1]{1to8}
+	vcvtne2ps2bf16 zmm1 {k1}, zmm2, [2*edx+4]{1to16}
+
+	vcvtneps2bf16 xmm1 {k1}, [eax]{1to4}
+	vcvtneps2bf16 xmm1 {k1}, [ecx+1]{1to8}
+	vcvtneps2bf16 ymm1 {k1}, [2*edx+4]{1to16}
+
+	vdpbf16ps xmm1 {k1}, xmm2, [eax]{1to4}
+	vdpbf16ps ymm1 {k1}, ymm2, [ecx+1]{1to8}
+	vdpbf16ps zmm1 {k1}, zmm2, [2*edx+4]{1to16}
+
+	vcvtne2ps2bf16 xmm1 {k1}, xmm2, xmm3
+	vcvtne2ps2bf16 ymm1 {k1}, ymm2, ymm3
+	vcvtne2ps2bf16 zmm1 {k1}, zmm2, zmm3
+
+	vcvtneps2bf16 xmm1 {k1}, xmm2
+	vcvtneps2bf16 xmm1 {k1}, ymm2
+	vcvtneps2bf16 ymm1 {k1}, zmm2
+
+	vdpbf16ps xmm1 {k1}{z}, xmm2, xmm3
+	vdpbf16ps ymm1 {k1}{z}, ymm2, ymm3
+	vdpbf16ps zmm1 {k1}{z}, zmm2, zmm3
+
+	vcvtne2ps2bf16 xmm1 {k1}{z}, xmm2, [eax]
+	vcvtne2ps2bf16 ymm1 {k1}{z}, ymm2, [ecx+1]
+	vcvtne2ps2bf16 zmm1 {k1}{z}, zmm2, [2*edx+64]
+
+	vcvtneps2bf16 xmm1 {k1}{z}, oword [eax]
+	vcvtneps2bf16 xmm1 {k1}{z}, yword [ecx+1]
+	vcvtneps2bf16 ymm1 {k1}{z}, [2*edx+64]
+
+	vdpbf16ps xmm1 {k1}{z}, xmm2, [eax]
+	vdpbf16ps ymm1 {k1}{z}, ymm2, [ecx+1]
+	vdpbf16ps zmm1 {k1}{z}, zmm2, [2*edx+64]
+
+	vcvtne2ps2bf16 xmm1 {k1}{z}, xmm2, [eax]{1to4}
+	vcvtne2ps2bf16 ymm1 {k1}{z}, ymm2, [ecx+1]{1to8}
+	vcvtne2ps2bf16 zmm1 {k1}{z}, zmm2, [2*edx+4]{1to16}
+
+	vcvtneps2bf16 xmm1 {k1}{z}, [eax]{1to4}
+	vcvtneps2bf16 xmm1 {k1}{z}, [ecx+1]{1to8}
+	vcvtneps2bf16 ymm1 {k1}{z}, [2*edx+4]{1to16}
+
+	vdpbf16ps xmm1 {k1}{z}, xmm2, [eax]{1to4}
+	vdpbf16ps ymm1 {k1}{z}, ymm2, [ecx+1]{1to8}
+	vdpbf16ps zmm1 {k1}{z}, zmm2, [2*edx+4]{1to16}

--- a/x86/insns.dat
+++ b/x86/insns.dat
@@ -5396,15 +5396,15 @@ XRESLDTRK	void				[	f2 0f 01 e9]				TSXLDTRK
 XSUSLDTRK	void				[	f2 0f 01 e8]				TSXLDTRK
 
 ;# AVX512 Bfloat16 instructions
-VCVTNE2PS2BF16	xmmreg|mask|z,xmmreg*,xmmrm128|b32	[rvm:fv:	evex.128.f2.0f38.w0 72 /r]	AVX512BF16
-VCVTNE2PS2BF16	ymmreg|mask|z,ymmreg*,ymmrm256|b32	[rvm:fv:	evex.256.f2.0f38.w0 72 /r]	AVX512BF16
+VCVTNE2PS2BF16	xmmreg|mask|z,xmmreg*,xmmrm128|b32	[rvm:fv:	evex.128.f2.0f38.w0 72 /r]	AVX512BF16,AVX512VL
+VCVTNE2PS2BF16	ymmreg|mask|z,ymmreg*,ymmrm256|b32	[rvm:fv:	evex.256.f2.0f38.w0 72 /r]	AVX512BF16,AVX512VL
 VCVTNE2PS2BF16	zmmreg|mask|z,zmmreg*,zmmrm512|b32	[rvm:fv:	evex.512.f2.0f38.w0 72 /r]	AVX512BF16
-VCVTNEPS2BF16	xmmreg|mask|z,xmmreg*,xmmrm128|b32	[rvm:fv:	evex.128.f3.0f38.w0 72 /r]	AVX512BF16
-VCVTNEPS2BF16	ymmreg|mask|z,ymmreg*,ymmrm256|b32	[rvm:fv:	evex.256.f3.0f38.w0 72 /r]	AVX512BF16
-VCVTNEPS2BF16	zmmreg|mask|z,zmmreg*,zmmrm512|b32	[rvm:fv:	evex.512.f3.0f38.w0 72 /r]	AVX512BF16
-VDPBF16PS	xmmreg|mask|z,xmmreg*,xmmrm128|b32	[rvm:fv:	evex.128.f3.0f38.w0 52 /r]	AVX512BF16
-VDPBF16PS	ymmreg|mask|z,ymmreg*,ymmrm128|b32	[rvm:fv:	evex.256.f3.0f38.w0 52 /r]	AVX512BF16
-VDPBF16PS	zmmreg|mask|z,zmmreg*,zmmrm128|b32	[rvm:fv:	evex.512.f3.0f38.w0 52 /r]	AVX512BF16
+VCVTNEPS2BF16   xmmreg|mask|z,xmmrm128|b32              [rm:fv:         evex.128.f3.0f38.w0 72 /r]      AVX512BF16,AVX512VL
+VCVTNEPS2BF16   xmmreg|mask|z,ymmrm256|b32              [rm:fv:         evex.256.f3.0f38.w0 72 /r]      AVX512BF16,AVX512VL
+VCVTNEPS2BF16   ymmreg|mask|z,zmmrm512|b32              [rm:fv:         evex.512.f3.0f38.w0 72 /r]      AVX512BF16
+VDPBF16PS	xmmreg|mask|z,xmmreg*,xmmrm128|b32	[rvm:fv:	evex.128.f3.0f38.w0 52 /r]	AVX512BF16,AVX512VL
+VDPBF16PS	ymmreg|mask|z,ymmreg*,ymmrm256|b32	[rvm:fv:	evex.256.f3.0f38.w0 52 /r]	AVX512BF16,AVX512VL
+VDPBF16PS	zmmreg|mask|z,zmmreg*,zmmrm512|b32	[rvm:fv:	evex.512.f3.0f38.w0 52 /r]	AVX512BF16
 
 ;# AVX512 mask intersect instructions
 VP2INTERSECTD	kreg|rs2,xmmreg,xmmrm128|b32		[rvm:fv:	evex.nds.128.f2.0f38.w0 68 /r]	AVX512VL,AVX512VP2INTERSECT


### PR DESCRIPTION
AVX512BF16 fix:
-- VCVTNEPS2BF16 operand count
-- VDPBF16PS operand size
AVX512BF16 test files
Checked with XED version: [v2025.06.08]