### PR TITLE
AVX512_VP2INTERSECT test files

### DIFF
--- a/test/avx512vp2intersect-64.asm
+++ b/test/avx512vp2intersect-64.asm
@@ -1,0 +1,48 @@
+BITS 64
+	vp2intersectd k0, xmm1, xmm2
+	vp2intersectd k0, ymm1, ymm2
+	vp2intersectd k0, zmm1, zmm2
+
+	vp2intersectq k0, xmm1, xmm2
+	vp2intersectq k0, ymm1, ymm2
+	vp2intersectq k0, zmm1, zmm2
+
+	vp2intersectd k1, xmm1, xmm2
+	vp2intersectd k1, ymm1, ymm2
+	vp2intersectd k1, zmm1, zmm2
+
+	vp2intersectq k1, xmm1, xmm2
+	vp2intersectq k1, ymm1, ymm2
+	vp2intersectq k1, zmm1, zmm2
+
+	vp2intersectd k0, xmm1, [rax]
+	vp2intersectd k0, ymm1, [rcx+1]
+	vp2intersectd k0, zmm1, [2*rdx+64]
+
+	vp2intersectq k0, xmm1, [rax]
+	vp2intersectq k0, ymm1, [rcx+1]
+	vp2intersectq k0, zmm1, [2*rdx+64]
+
+	vp2intersectd k1, xmm1, [rax]
+	vp2intersectd k1, ymm1, [rcx+1]
+	vp2intersectd k1, zmm1, [2*rdx+64]
+
+	vp2intersectq k1, xmm1, [rax]
+	vp2intersectq k1, ymm1, [rcx+1]
+	vp2intersectq k1, zmm1, [2*rdx+64]
+
+	vp2intersectd k0, xmm1, [rax]{1to4}
+	vp2intersectd k0, ymm1, [rcx+1]{1to8}
+	vp2intersectd k0, zmm1, [2*rdx+4]{1to16}
+
+	vp2intersectq k0, xmm1, [rax]{1to2}
+	vp2intersectq k0, ymm1, [rcx+1]{1to4}
+	vp2intersectq k0, zmm1, [2*rdx+8]{1to8}
+
+	vp2intersectd k1, xmm1, [rax]{1to4}
+	vp2intersectd k1, ymm1, [rcx+1]{1to8}
+	vp2intersectd k1, zmm1, [2*rdx+4]{1to16}
+
+	vp2intersectq k1, xmm1, [rax]{1to2}
+	vp2intersectq k1, ymm1, [rcx+1]{1to4}
+	vp2intersectq k1, zmm1, [2*rdx+8]{1to8}

--- a/test/avx512vp2intersect.asm
+++ b/test/avx512vp2intersect.asm
@@ -1,0 +1,48 @@
+BITS 32
+	vp2intersectd k0, xmm1, xmm2
+	vp2intersectd k0, ymm1, ymm2
+	vp2intersectd k0, zmm1, zmm2
+
+	vp2intersectq k0, xmm1, xmm2
+	vp2intersectq k0, ymm1, ymm2
+	vp2intersectq k0, zmm1, zmm2
+
+	vp2intersectd k1, xmm1, xmm2
+	vp2intersectd k1, ymm1, ymm2
+	vp2intersectd k1, zmm1, zmm2
+
+	vp2intersectq k1, xmm1, xmm2
+	vp2intersectq k1, ymm1, ymm2
+	vp2intersectq k1, zmm1, zmm2
+
+	vp2intersectd k0, xmm1, [eax]
+	vp2intersectd k0, ymm1, [ecx+1]
+	vp2intersectd k0, zmm1, [2*edx+64]
+
+	vp2intersectq k0, xmm1, [eax]
+	vp2intersectq k0, ymm1, [ecx+1]
+	vp2intersectq k0, zmm1, [2*edx+64]
+
+	vp2intersectd k1, xmm1, [eax]
+	vp2intersectd k1, ymm1, [ecx+1]
+	vp2intersectd k1, zmm1, [2*edx+64]
+
+	vp2intersectq k1, xmm1, [eax]
+	vp2intersectq k1, ymm1, [ecx+1]
+	vp2intersectq k1, zmm1, [2*edx+64]
+
+	vp2intersectd k0, xmm1, [eax]{1to4}
+	vp2intersectd k0, ymm1, [ecx+1]{1to8}
+	vp2intersectd k0, zmm1, [2*edx+4]{1to16}
+
+	vp2intersectq k0, xmm1, [eax]{1to2}
+	vp2intersectq k0, ymm1, [ecx+1]{1to4}
+	vp2intersectq k0, zmm1, [2*edx+8]{1to8}
+
+	vp2intersectd k1, xmm1, [eax]{1to4}
+	vp2intersectd k1, ymm1, [ecx+1]{1to8}
+	vp2intersectd k1, zmm1, [2*edx+4]{1to16}
+
+	vp2intersectq k1, xmm1, [eax]{1to2}
+	vp2intersectq k1, ymm1, [ecx+1]{1to4}
+	vp2intersectq k1, zmm1, [2*edx+8]{1to8}


### PR DESCRIPTION
AVX512_VP2INTERSECT 32b/64b test files
Checked with XED version: [v2025.06.08]

Although Intel deprecated AVX512_VP2INTERSECT instructions, Leslie A Barnes (CVP AMD Cores) announced in my twitter feed that AMD will support these in future AMD products: https://x.com/LeslieB82382206/status/1890264424612872269