### PR TITLE
AVX-NE-CONVERT fix

### DIFF
--- a/test/avx-ne-convert-64.asm
+++ b/test/avx-ne-convert-64.asm
@@ -1,0 +1,20 @@
+BITS 64
+	vbcstnebf16ps xmm1, [rax]
+	vbcstnebf16ps ymm1, [rax]
+	vbcstnebf162ps xmm1, [rax]
+	vbcstnebf162ps ymm1, [rax]
+	vbcstnesh2ps xmm1, [rax]
+	vbcstnesh2ps ymm1, [rax]
+	vcvtneebf162ps xmm1, oword [rbx]
+	vcvtneebf162ps ymm1, yword [rcx]
+	vcvtneeph2ps xmm1, oword [rbx]
+	vcvtneeph2ps ymm1, yword [rcx]
+	vcvtneobf162ps xmm1, oword [rbx]
+	vcvtneobf162ps ymm1, yword [rcx]
+	vcvtneoph2ps xmm1, oword [rbx]
+	vcvtneoph2ps ymm1, yword [rcx]
+cpu latevex
+	vcvtneps2bf16 xmm1, xmm2
+	vcvtneps2bf16 xmm1, ymm2
+	vcvtneps2bf16 xmm1, oword [rbx]
+	vcvtneps2bf16 xmm1, yword [rbx]

--- a/test/avx-ne-convert.asm
+++ b/test/avx-ne-convert.asm
@@ -1,0 +1,20 @@
+BITS 32
+	vbcstnebf16ps xmm1, [eax]
+	vbcstnebf16ps ymm1, [eax]
+	vbcstnebf162ps xmm1, [eax]
+	vbcstnebf162ps ymm1, [eax]
+	vbcstnesh2ps xmm1, [eax]
+	vbcstnesh2ps ymm1, [eax]
+	vcvtneebf162ps xmm1, oword [ebx]
+	vcvtneebf162ps ymm1, yword [ecx]
+	vcvtneeph2ps xmm1, oword [ebx]
+	vcvtneeph2ps ymm1, yword [ecx]
+	vcvtneobf162ps xmm1, oword [ebx]
+	vcvtneobf162ps ymm1, yword [ecx]
+	vcvtneoph2ps xmm1, oword [ebx]
+	vcvtneoph2ps ymm1, yword [ecx]
+cpu latevex
+	vcvtneps2bf16 xmm1, xmm2
+	vcvtneps2bf16 xmm1, ymm2
+	vcvtneps2bf16 xmm1, oword [ebx]
+	vcvtneps2bf16 xmm1, yword [ebx]

--- a/x86/insns.dat
+++ b/x86/insns.dat
@@ -2983,22 +2983,22 @@ VSM4RNDS4       zmmreg,zmmreg,zmmrm512              [rvm: evex.nds.512.f2.0f38.w
 
 ;# AVX no exception conversions
 ; Must precede AVX-512 versions
-VBCSTNEBF16PS	xmmreg,mem16				[rm:	vex.128.f3.0f38.w0 b1 /r]	AVXNECONVERT,LATEVEX,SW
-VBCSTNEBF16PS	ymmreg,mem16				[rm:	vex.256.f3.0f38.w0 b1 /r]	AVXNECONVERT,LATEVEX,SW
-VBCSTNEBF162PS	xmmreg,mem16				[rm:	vex.128.f3.0f38.w0 b1 /r]	AVXNECONVERT,LATEVEX,SW
-VBCSTNEBF162PS	ymmreg,mem16				[rm:	vex.256.f3.0f38.w0 b1 /r]	AVXNECONVERT,LATEVEX,SW
-VBCSTNESH2PS	xmmreg,mem16				[rm:	vex.128.66.0f38.w0 b1 /r]	AVXNECONVERT,LATEVEX,SW
-VBCSTNESH2PS	ymmreg,mem16				[rm:	vex.256.66.0f38.w0 b1 /r]	AVXNECONVERT,LATEVEX,SW
-VCVTNEEBF162PS	xmmreg,mem128				[rm:	vex.128.f3.0f38.w0 b0 /r]	AVXNECONVERT,LATEVEX,SO
-VCVTNEEBF162PS	ymmreg,mem256				[rm:	vex.256.f3.0f38.w0 b0 /r]	AVXNECONVERT,LATEVEX,SY
-VCVTNEEPH2PS	xmmreg,mem128				[rm:	vex.128.66.0f38.w0 b0 /r]	AVXNECONVERT,LATEVEX,SO
-VCVTNEEPH2PS	ymmreg,mem256				[rm:	vex.256.66.0f38.w0 b0 /r]	AVXNECONVERT,LATEVEX,SY
-VCVTNEOBF162PS	xmmreg,mem128				[rm:	vex.128.f2.0f38.w0 b0 /r]	AVXNECONVERT,LATEVEX,SO
-VCVTNEOBF162PS	ymmreg,mem256				[rm:	vex.256.f2.0f38.w0 b0 /r]	AVXNECONVERT,LATEVEX,SY
-VCVTNEOPH2PS	xmmreg,mem128				[rm:	vex.128.np.0f38.w0 b0 /r]	AVXNECONVERT,LATEVEX,SO
-VCVTNEOPH2PS	ymmreg,mem256				[rm:	vex.256.np.0f38.w0 b0 /r]	AVXNECONVERT,LATEVEX,SY
+VBCSTNEBF16PS	xmmreg,mem16				[rm:	vex.128.f3.0f38.w0 b1 /r]	AVXNECONVERT,SW
+VBCSTNEBF16PS	ymmreg,mem16				[rm:	vex.256.f3.0f38.w0 b1 /r]	AVXNECONVERT,SW
+VBCSTNEBF162PS	xmmreg,mem16				[rm:	vex.128.f3.0f38.w0 b1 /r]	AVXNECONVERT,SW
+VBCSTNEBF162PS	ymmreg,mem16				[rm:	vex.256.f3.0f38.w0 b1 /r]	AVXNECONVERT,SW
+VBCSTNESH2PS	xmmreg,mem16				[rm:	vex.128.66.0f38.w0 b1 /r]	AVXNECONVERT,SW
+VBCSTNESH2PS	ymmreg,mem16				[rm:	vex.256.66.0f38.w0 b1 /r]	AVXNECONVERT,SW
+VCVTNEEBF162PS	xmmreg,mem128				[rm:	vex.128.f3.0f38.w0 b0 /r]	AVXNECONVERT,SO
+VCVTNEEBF162PS	ymmreg,mem256				[rm:	vex.256.f3.0f38.w0 b0 /r]	AVXNECONVERT,SY
+VCVTNEEPH2PS	xmmreg,mem128				[rm:	vex.128.66.0f38.w0 b0 /r]	AVXNECONVERT,SO
+VCVTNEEPH2PS	ymmreg,mem256				[rm:	vex.256.66.0f38.w0 b0 /r]	AVXNECONVERT,SY
+VCVTNEOBF162PS	xmmreg,mem128				[rm:	vex.128.f2.0f38.w0 b0 /r]	AVXNECONVERT,SO
+VCVTNEOBF162PS	ymmreg,mem256				[rm:	vex.256.f2.0f38.w0 b0 /r]	AVXNECONVERT,SY
+VCVTNEOPH2PS	xmmreg,mem128				[rm:	vex.128.np.0f38.w0 b0 /r]	AVXNECONVERT,SO
+VCVTNEOPH2PS	ymmreg,mem256				[rm:	vex.256.np.0f38.w0 b0 /r]	AVXNECONVERT,SY
 VCVTNEPS2BF16	xmmreg,xmmrm128				[rm:	vex.128.f3.0f38.w0 72 /r]	AVXNECONVERT,LATEVEX,SO
-VCVTNEPS2BF16	ymmreg,ymmrm256				[rm:	vex.256.f3.0f38.w0 72 /r]	AVXNECONVERT,LATEVEX,SY
+VCVTNEPS2BF16	xmmreg,ymmrm256				[rm:	vex.256.f3.0f38.w0 72 /r]	AVXNECONVERT,LATEVEX,SY
 
 ;# AVX Vector Neural Network Instructions
 ; Must precede AVX-512 versions


### PR DESCRIPTION
AVX-NE-CONVERT fix:
- only VCVTNEPS2BF16 has EVEX version 
AVX-NE-CONVERT 32b/64b test files
Checked with XED version: [v2025.06.08]