### PR TITLE
fix [warning push] causing "unknown warning name"

### DIFF
--- a/asm/directiv.c
+++ b/asm/directiv.c
@@ -526,8 +526,9 @@ bool process_directives(char *directive)
                 push_warnings();
             else if (!nasm_stricmp(value, "pop"))
                 pop_warnings();
+        } else {
+            set_warning_status(value);
         }
-        set_warning_status(value);
         break;
 
     case D_CPU:         /* [CPU] */

--- a/travis/test/warnstack.json
+++ b/travis/test/warnstack.json
@@ -4,7 +4,7 @@
 		"id": "warnstack",
 		"format": "bin",
 		"source": "warnstack.asm",
-		"option": "-Ox",
+		"option": "-Ox -w+unknown-warning",
 		"target": [
 			{ "output": "warnstack.bin" },
 			{ "stderr": "warnstack.stderr" }


### PR DESCRIPTION
[warning push] emitted a "unknown warning name" warning when -w+unknown-warning is set.