### PR TITLE
fix filename_set_extension to always terminate the resulting string with null

### DIFF
--- a/nasmlib/path.c
+++ b/nasmlib/path.c
@@ -219,9 +219,11 @@ const char *filename_set_extension(const char *inname, const char *extension)
 
     q = outname = nasm_malloc(baselen + elen + 1);
     q = mempcpy(q, inname, baselen);
-    if (*extension)
+    if (*extension) {
         *q++ = extsep;
-    memcpy(q, extension+1, elen);
+        memcpy(q, extension+1, elen);
+    } else
+        *q++ = '\0';
 
     return outname;
 }


### PR DESCRIPTION
Nasm produces heap buffer overflow when invoked with the following command line:

```
    $ nasm 1.asm
```

`-fsanitize=address` prints the following call stack:

```
READ of size 1 at 0x5020000000b2 thread T0
    #0 0x646bbff40d3d in quote_for_pmake asm/nasm.c:744
    #1 0x646bbff3ffa3 in main asm/nasm.c:564
    #2 0x76656662a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #3 0x76656662a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #4 0x646bbff3be84 in _start (nasm+0x34be84)
```

The problem is caused by the fact that:

* `ofmt::extension` for raw binary file is a empty string `""`,
* when `filename_set_extension` is called with empty string as extension it produces a non-null-terminated string,
* the result of `filename_set_extension` is passed to `quote_for_pmake`, which expects a null-terminated string.

This commit fixes the bug by changing `filename_set_extension` so it always appends the null terminator to the resulting string.