### PR TITLE
Some fixes for NASM

### DIFF
--- a/asm/eval.c
+++ b/asm/eval.c
@@ -614,6 +614,13 @@ static expr *expr5(void)
             nasm_nonfatal("division by zero");
             return NULL;
         }
+        if ((tto == TOKEN_SDIV || tto == TOKEN_SMOD) &&
+            !is_just_unknown(e) && !is_just_unknown(f) &&
+            (int64_t)reloc_value(e) == INT64_MIN &&
+            (int64_t)reloc_value(f) == -1) {
+            nasm_nonfatal("signed division overflow");
+            return NULL;
+        }
         switch (tto) {
         case '*':
             if (is_simple(e))

--- a/asm/parser.c
+++ b/asm/parser.c
@@ -566,6 +566,11 @@ static int parse_eops(extop **result, bool critical, int elem)
                     nasm_nonfatal("negative argument supplied to DUP");
                     goto fail;
                 }
+                if (value->value &&
+                    eop->dup > SIZE_MAX / (size_t)value->value) {
+                    nasm_nonfatal("DUP count overflow");
+                    goto fail;
+                }
                 eop->dup *= (size_t)value->value;
                 do_subexpr = true;
                 continue;
@@ -1290,6 +1295,10 @@ restart_parse:
                  * put the decorator information in the (opflag_t) type field
                  * of previous operand.
                  */
+                if (opnum == 0) {
+                    nasm_nonfatal("decorator without preceding operand");
+                    goto fail;
+                }
                 opnum--; op--;
                 switch (value->value) {
                 case BRC_RN:


### PR DESCRIPTION

File: disasm/disasm.c
Finding: H-01 - Stack buffer overflow in disassembler output

Root cause:
    The disasm() function builds instruction text output using
    slen += snprintf(output+slen, outbufsize-slen, ...) followed
    by direct byte writes like output[slen++] = separator. The
    snprintf() return value is the number of characters that
    *would* have been written, not the actual count. When the
    formatted instruction exceeds the buffer, slen grows past
    outbufsize, causing (outbufsize - slen) to underflow to a
    huge value for subsequent snprintf calls (disabling truncation),
    and direct byte writes to go out of bounds. The caller ndisasm.c
    uses a 256-byte stack buffer, making this a stack buffer overflow
    exploitable via crafted binary input.

Fix:
    Added OUTBUF_CLAMP() and OUTBUF_CHAR() macros. OUTBUF_CLAMP()
    is called after every snprintf to cap slen at outbufsize-1,
    preventing the return value from exceeding the buffer. OUTBUF_CHAR()
    replaces all direct output[slen++] writes with a bounds-checked
    version. Output is safely truncated rather than overflowing.

---------------------------------------------------------------

File: asm/eval.c
Finding: H-02 - Signed integer division crash (INT64_MIN / -1)

Root cause:
    The expression evaluator in expr5() handles TOKEN_SDIV and
    TOKEN_SMOD by casting operands to int64_t and performing C
    signed division/modulo. The code checks for division by zero
    but not for the case INT64_MIN / -1, which is undefined
    behavior in C and causes a SIGFPE (floating point exception)
    on x86 platforms due to the result not being representable in
    int64_t. An attacker can crash nasm with: db (-9223372036854775808 // -1)

Fix:
    Added a check after the existing division-by-zero guard that
    detects when the dividend is INT64_MIN and the divisor is -1
    for TOKEN_SDIV and TOKEN_SMOD operations. This case now emits
    a "signed division overflow" error and returns NULL instead of
    performing the undefined division.

---------------------------------------------------------------

File: asm/parser.c
Finding: H-04 - Operand index underflow in RDSAE decorator

Root cause:
    When parsing EXPR_RDSAE decorators (rounding/SAE for AVX-512),
    the code unconditionally decrements opnum and the operand
    pointer (opnum--; op--;) to apply the decorator to the
    preceding operand. If the decorator appears as the first token
    before any operand, opnum wraps from 0 to -1 and op points to
    oprs[-1], causing an out-of-bounds memory write when setting
    op->decoflags.

Fix:
    Added a guard checking opnum == 0 before the decrement. When
    triggered, the parser emits a "decorator without preceding
    operand" error and jumps to the fail label, preventing the
    underflow and out-of-bounds access.

---------------------------------------------------------------

File: asm/parser.c
Finding: H-05 - DUP count integer overflow

Root cause:
    The DUP operator multiplies eop->dup by the user-supplied
    count: eop->dup *= (size_t)value->value. With nested DUP
    expressions (e.g., "db 4294967296 DUP 4294967296 DUP 0"),
    this multiplication can silently overflow size_t, wrapping
    to a small value. This leads to an undersized allocation
    followed by a write of the full intended data, causing a
    heap buffer overflow.

Fix:
    Added an overflow check before the multiplication: if
    value->value is non-zero and eop->dup exceeds
    SIZE_MAX / value->value, the multiplication would overflow.
    This case now emits a "DUP count overflow" error and jumps
    to the fail label.

---------------------------------------------------------------

File: output/outieee.c
Finding: H-14 - Stack buffer overflow in IEEE symbol name copy

Root cause:
    The ieee_unqualified_name() function copies a symbol name
    into a destination buffer using strcpy (or a manual toupper
    loop) without any length check. All callers pass a char buf[256]
    stack buffer. Since symbol names from assembly source can be
    arbitrarily long, a symbol name exceeding 255 characters causes
    a classic stack buffer overflow.

Fix:
    Added a destsize parameter to ieee_unqualified_name(). The
    function now computes the source length, clamps it to
    destsize-1, and uses bounded copy (memcpy with explicit NUL
    termination) instead of strcpy. The toupper loop is similarly
    bounded. All callers updated to pass sizeof(buf). Names longer
    than 255 characters are safely truncated.