### PR TITLE
Fix #206 CMP AL, 4 by modifying x86/preinsns.pl to include reg_al in arithmetic instruction …

### DIFF
--- a/x86/preinsns.pl
+++ b/x86/preinsns.pl
@@ -24,6 +24,7 @@ $macros{'arith'} = {
     'txt' => <<'EOL'
 $$bwdq $op	rm#,reg#			[mr:	$hle o# $00# /r				]	8086,FL,SM,$lock
 $$bwdq $op	reg#,rm#			[rm:	o# $02# /r				]	8086,FL,SM
+$op		reg_al,imm8			[-i:	o8 $04 ib				]	8086,FL,SM
 $op		rm8,imm8			[mi:	$hle 80 /$n ib				]	8086,FL,SM,$lock
 $op		rm16,sbyteword16		[mi:	$hle o16 83 /$n ib,s			]	8086,FL,SM,$lock
 $op		reg_ax,imm16			[-i:	o16 $05 iw				]	8086,FL,SM


### PR DESCRIPTION
Issue #206 originally referenced the instruction cmp al, 4 not assembling to the two-byte binary instruction, as shown in the comparison in the issue. The instructions `add, or, adc, sbb, and, sub, xor` were also affected by the error.

In commit f0dc7c220dfb13b4d263babbbb6b8a1616fec866 the change to x86/preinsns.pl didn't include the pattern for `reg_al` immediate encoding, which resulted in every immediate encoded instruction using `al` in the arithmetic pattern not being placed in the compiled insns files off `insns.dat`.

The debugging information added to `itemplate` structure in fbacd59cce7c01e67c508f7bfe34b65d255b85e9 assisted me directly in finding the root cause of this issue, as I was able to quickly find the discrepancy between insns.xda made from the current GitHub version compared to a previous version (I used v3.01). Thank you for adding that information.

Due to the issue being in preinsns.pl, the issue was also present when disassembling the bytes `3C04` from issue #206  using the current github version, which is also fixed now. When disassembled, the output gave two define byte pseudo-ops (db 3C, db 04).

Thank you for reading this pull request, and let me know if you need any changes made or such.