### PR TITLE
[3.02rc regression] output/codeview: don't panic when there is not code section

### DIFF
--- a/output/codeview.c
+++ b/output/codeview.c
@@ -759,12 +759,14 @@ static void build_symbol_table(struct coff_Section *const sect)
 {
     section_write32(sect, 0x00000004);
 
-    write_filename_table(sect);
-    align4_table(sect);
-    write_sourcefile_table(sect);
-    align4_table(sect);
-    write_linenumber_table(sect);
-    align4_table(sect);
+    if (cv8_state.source_files) {
+        write_filename_table(sect);
+        align4_table(sect);
+        write_sourcefile_table(sect);
+        align4_table(sect);
+        write_linenumber_table(sect);
+        align4_table(sect);
+    }
     write_symbolinfo_table(sect);
     align4_table(sect);
 }


### PR DESCRIPTION
Simply skip the tables that require code section and source information.

Fixes: #216
Fixes: https://github.com/netwide-assembler/nasm/pull/178#issuecomment-4156226648