### PR TITLE
parser: fix invalid segment override on EQU FAR pointers

### DIFF
--- a/asm/labels.c
+++ b/asm/labels.c
@@ -210,7 +210,11 @@ static union label *find_label(const char *label, bool create, bool *created)
     if (lptr || !create) {
         if (created)
             *created = false;
-        return lptr;
+       	if (label_str) {
+		nasm_free(label_str);
+	}
+
+       	return lptr;
     }
 
     /* Create a new label... */

--- a/asm/parser.c
+++ b/asm/parser.c
@@ -1106,7 +1106,7 @@ restart_parse:
                  * as if it had ended in a comma, but sets the COLON flag
                  * on the operand further down.
                  */
-            } else if (mref || !far_jmp_ok) {
+            } else if (mref || (ok_reg && IS_SREG(value->type))) {
                 /* segment override? */
                 mref = true;
 

--- a/x86/insns.dat
+++ b/x86/insns.dat
@@ -5449,9 +5449,9 @@ VCOMISH		xmmreg,xmmrm16|sae			[rm:fv:	  evex.lig.np.map5.w0 2F /r]	    AVX512FP1
 VCVTDQ2PH	xmmreg|mask|z,xmmrm128|b32		[rm:fv:	  evex.128.np.map5.w0 5B /r]	    AVX512FP16,AVX512VL
 VCVTDQ2PH	xmmreg|mask|z,ymmrm256|b32		[rm:fv:	  evex.256.np.map5.w0 5B /r]	    AVX512FP16,AVX512VL
 VCVTDQ2PH	ymmreg|mask|z,zmmrm512|b32|er		[rm:fv:	  evex.512.np.map5.w0 5B /r]	    AVX512FP16
-VCVTPD2PH	xmmreg|mask|z,xmmrm128|b64		[rm:fv:	  evex.128.66.map5.w1 5A /r]	    AVX512FP16,AVX512VL
-VCVTPD2PH	xmmreg|mask|z,ymmrm256|b64		[rm:fv:	  evex.256.66.map5.w1 5A /r]	    AVX512FP16,AVX512VL
-VCVTPD2PH	xmmreg|mask|z,zmmrm512|b64|er		[rm:fv:	  evex.512.66.map5.w1 5A /r]	    AVX512FP16
+VCVTPD2PH	xmmreg|mask|z,xmmrm128|b64	[rm:fv: evex.128.66.map5.w1 5a /r]	AVX512FP16,AVX512VL
+VCVTPD2PH	xmmreg|mask|z,ymmrm256|b64	[rm:fv: evex.256.66.map5.w1 5a /r]	AVX512FP16,AVX512VL
+VCVTPD2PH	xmmreg|mask|z,zmmrm512|b64|er	[rm:fv: evex.512.66.map5.w1 5a /r]	AVX512FP16
 VCVTPH2DQ	xmmreg|mask|z,xmmrm64|b16		[rm:hv:	  evex.128.66.map5.w0 5B /r]	    AVX512FP16,AVX512VL
 VCVTPH2DQ	ymmreg|mask|z,xmmrm128|b16		[rm:hv:	  evex.256.66.map5.w0 5B /r]	    AVX512FP16,AVX512VL
 VCVTPH2DQ	zmmreg|mask|z,ymmrm256|b16|er		[rm:hv:	  evex.512.66.map5.w0 5B /r]	    AVX512FP16
@@ -5682,6 +5682,14 @@ VSUBPH		ymmreg|mask|z,ymmreg*,ymmrm256|b16	[rvm:fv: evex.nds.256.np.map5.w0 5c /
 VSUBPH		zmmreg|mask|z,zmmreg*,zmmrm512|b16|er	[rvm:fv: evex.nds.512.np.map5.w0 5c /r]	AVX512FP16
 VSUBSH		xmmreg|mask|z,xmmreg*,xmmrm16|er	[rvm:t1s: evex.nds.lig.f3.map5.w0 5c /r]	AVX512FP16
 VUCOMISH	xmmreg,xmmrm16|sae			[rm:t1s: evex.lig.np.map5.w0 2e /r]	AVX512FP16
+VMINPH	xmmreg|mask|z,xmmreg*,xmmrm128|b16	[rvm:fv: evex.128.np.map5.w0 5d /r]	AVX512FP16,AVX512VL
+VMINPH	ymmreg|mask|z,ymmreg*,ymmrm256|b16	[rvm:fv: evex.256.np.map5.w0 5d /r]	AVX512FP16,AVX512VL
+VMINPH	zmmreg|mask|z,zmmreg*,zmmrm512|b16|sae	[rvm:fv: evex.512.np.map5.w0 5d /r]	AVX512FP16
+VMINSH	xmmreg|mask|z,xmmreg*,xmmrm16|sae	[rvm:t1s: evex.lig.f3.map5.w0 5d /r]	AVX512FP16
+VMAXPH	xmmreg|mask|z,xmmreg*,xmmrm128|b16	[rvm:fv: evex.128.np.map5.w0 57 /r]	AVX512FP16,AVX512VL
+VMAXPH	ymmreg|mask|z,ymmreg*,ymmrm256|b16	[rvm:fv: evex.256.np.map5.w0 57 /r]	AVX512FP16,AVX512VL
+VMAXPH	zmmreg|mask|z,zmmreg*,zmmrm512|b16|sae	[rvm:fv: evex.512.np.map5.w0 57 /r]	AVX512FP16
+VMAXSH	xmmreg|mask|z,xmmreg*,xmmrm16|sae	[rvm:t1s: evex.lig.f3.map5.w0 57 /r]	AVX512FP16
 
 ;# RAO-INT weakly ordered atomic operations
 $dq  AADD	mem#,reg#				[mr:	o# np 0f38 fc /r	]	RAOINT,SQ,LONG


### PR DESCRIPTION
The parser incorrectly treated colons as memory segment overrides inside EQU directives because of an inverted far_jmp_ok check. This regression was introduced in commit 8981724. Removing the incorrect negation restores proper parsing of FAR pointer constants.

Fixes #242