### PR TITLE
output/outelf.c: free the section name and struct on cleanup

### DIFF
--- a/output/outelf.c
+++ b/output/outelf.c
@@ -595,6 +595,8 @@ static void elf_cleanup(void)
             sects[i]->head = sects[i]->head->next;
             nasm_free(r);
         }
+        nasm_free(sects[i]->name);
+        nasm_free(sects[i]);
     }
     hash_free(&section_by_name);
     raa_free(section_by_index);


### PR DESCRIPTION
elf_cleanup() frees each section's data, relocations and reloc list,
then frees the `sects` pointer array itself - but never the section
structs it points to, nor their strdup'd names. Every section leaks
on every ELF run. This is the ELF counterpart of the outobj.c
"free the section name on cleanup" fix.

Confirmed with `leaks` (macOS): a multi-section elf64 assemble went
from "11 leaks for 864 total leaked bytes" to zero. Output is
byte-for-byte identical before and after across elf32/elf64/elfx32
including -F dwarf and -F stabs.

---

Sorry, I forgot the sign-off. Please add:

Signed-off-by: Anton Kochergin <succubus.vwv@gmail.com>