### PR TITLE
preproc: move strlen out of loop for better codegeneration

### DIFF
--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -6101,6 +6101,7 @@ expand_smacro_with_params(SMacro *m, Token *mstart, Token **params,
 
     tup = tline = NULL;
     cond_comma = false;
+    size_t mlen = m->name ? strlen(m->name) : 0;
 
     while (t) {
         enum token_type type = t->type;
@@ -6117,7 +6118,6 @@ expand_smacro_with_params(SMacro *m, Token *mstart, Token **params,
         case TOKEN_PREPROC_QQ:
         case TOKEN_PREPROC_SQQ:
         {
-            size_t mlen = strlen(m->name);
 	    size_t len;
             char *p, *from;
 


### PR DESCRIPTION
Fix common C/C++ compiler flaw is that it doesn't optimize strlen calls inside loops.

Reference: https://stackoverflow.com/questions/78827988/why-doesnt-the-compiler-optimize-strlen-calls-in-a-loop-despite-it-being-a-p