### PR TITLE
asm: nasmlib: remove excess checks before free()

### DIFF
--- a/asm/assemble.c
+++ b/asm/assemble.c
@@ -1016,8 +1016,7 @@ static int64_t assemble(insn *instruction)
                           " reading file `%s'", fname);
         }
     close_done:
-        if (buf)
-            nasm_free(buf);
+        nasm_free(buf);
         if (map)
             nasm_unmap_file(map, len);
         fclose(fp);

--- a/asm/labels.c
+++ b/asm/labels.c
@@ -210,8 +210,7 @@ static union label *find_label(const char *label, bool create, bool *created)
     if (lptr || !create) {
         if (created)
             *created = false;
-        if (label_str)
-            nasm_free(label_str);
+        nasm_free(label_str);
 
         return lptr;
     }
@@ -232,8 +231,7 @@ static union label *find_label(const char *label, bool create, bool *created)
     nasm_zero(*lfree);
     lfree->defn.label     = perm_copy(label);
     lfree->defn.subsection = NO_SEG;
-    if (label_str)
-        nasm_free(label_str);
+    nasm_free(label_str);
 
     hash_add(&ip, lfree->defn.label, lfree);
     return lfree++;

--- a/asm/parser.c
+++ b/asm/parser.c
@@ -618,8 +618,7 @@ static int parse_eops(extop **result, bool critical, int elem)
     return oper_num;
 
 fail:
-    if (eop)
-        nasm_free(eop);
+    nasm_free(eop);
     return -1;
 }
 

--- a/asm/preproc.c
+++ b/asm/preproc.c
@@ -950,7 +950,6 @@ static const char *pp_getenv(const Token *t, bool warn)
 	v = "";
     }
 
-    if (buf)
 	nasm_free(buf);
 
     return v;

--- a/nasmlib/alloc.c
+++ b/nasmlib/alloc.c
@@ -74,8 +74,7 @@ void *nasm_realloc(void *q, size_t size)
 
 void nasm_free(void *q)
 {
-    if (q)
-        free(q);
+    free(q);
 }
 
 char *nasm_strdup(const char *s)
@@ -103,8 +102,7 @@ char *nasm_strdupto(char **ptrp, const char *str)
 {
     char *ptr = *ptrp;
     if (str) {
-        if (ptr)
-            nasm_free(ptr);
+        nasm_free(ptr);
         *ptrp = ptr = nasm_strdup(str);
     }
     return ptr;

--- a/nasmlib/hashtbl.c
+++ b/nasmlib/hashtbl.c
@@ -251,8 +251,7 @@ void hash_free_all(struct hash_table *head, bool free_keys)
     const struct hash_node *np;
 
     hash_for_each(head, it, np) {
-        if (np->data)
-            nasm_free(np->data);
+        nasm_free(np->data);
         if (free_keys && np->key)
             nasm_free((void *)np->key);
     }


### PR DESCRIPTION
More info: https://stackoverflow.com/questions/13818803/check-for-null-before-delete-in-c-good-practice

In C this became possible after C89, code is cleaner.

```
 C89: 4.10.3.2 The free function.

The free function causes the space pointed to by ptr to be deallocated, that is,
made available for further allocation. If ptr is a null pointer, no action occurs.
```