### PR TITLE
outaout: align struct Symbol decrease size 56 to 48 bytes

### DIFF
--- a/output/outaout.c
+++ b/output/outaout.c
@@ -44,10 +44,10 @@ struct Symbol {
     int32_t value;                 /* address, or COMMON variable size */
     int32_t size;                  /* size for data or function exports */
     int32_t segment;               /* back-reference used by gsym_reloc */
+    int32_t symnum;                /* index into symbol table */
     struct Symbol *next;        /* list of globals in each section */
     struct Symbol *nextfwd;     /* list of unresolved-size symbols */
     char *name;                 /* for unresolved-size symbols */
-    int32_t symnum;                /* index into symbol table */
 };
 
 /*


### PR DESCRIPTION
If you know how to use [pahole](https://linux.die.net/man/1/pahole), then you can view the object files in release, debug, non-optimized debug, and so on. By default, C/C++ compilers do not change the size of structures until the programmer himself specifies the packing or alignment attribute (keyword).

Affected structs (cache size before and after):
- Symbol 56 -> 48 bytes

References:

- https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml

- https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf

- https://en.wikipedia.org/wiki/Data_structure_alignment

- https://stackoverflow.com/a/20882083

- https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/