### PR TITLE
codeview: align struct cv8_symbol decrease size 40 to 32 bytes

### DIFF
--- a/output/codeview.c
+++ b/output/codeview.c
@@ -85,8 +85,8 @@ enum symbol_type {
 };
 
 struct cv8_symbol {
-    enum symbol_type type;
     char *name;
+    enum symbol_type type;
 
     uint32_t secrel;
     uint16_t section;


### PR DESCRIPTION
Ref: https://github.com/netwide-assembler/nasm/pull/270

Affected structs (cache size before and after):
- cv8_symbol 40 -> 32 bytes