### PR TITLE
pecoff: align struct coff_Symbol decrease size 32 to 28 bytes

### DIFF
--- a/output/pecoff.h
+++ b/output/pecoff.h
@@ -487,14 +487,14 @@ struct coff_SymIdxReloc {
 };
 
 struct coff_Symbol {
-    char name[9];
     int32_t strpos;             /* string table position of name */
     int32_t value;              /* address, or COMMON variable size */
     int section;                /* section number where it's defined
                                  * - in COFF codes, not NASM codes */
-    bool is_global;             /* is it a global symbol or not? */
-    int16_t type;               /* 0 - notype, 0x20 - function */
     int32_t namlen;             /* full name length */
+    char name[9];
+    int16_t type;               /* 0 - notype, 0x20 - function */
+    bool is_global;             /* is it a global symbol or not? */
 };
 
 struct coff_DebugInfo {


### PR DESCRIPTION
Ref PR: https://github.com/netwide-assembler/nasm/pull/270

Affected classes (cache size before and after):
- coff_Symbol 32 -> 28 bytes

References:

- https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml

- https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf

- https://en.wikipedia.org/wiki/Data_structure_alignment

- https://stackoverflow.com/a/20882083

- https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/