### PR TITLE
outaout: fix dangeours truncating memsize to 32bit

### DIFF
--- a/output/outaout.c
+++ b/output/outaout.c
@@ -277,7 +277,7 @@ static void aout_deflabel(char *name, int32_t segment, int64_t offset,
         return;                 /* it wasn't an important one */
     }
 
-    saa_wbytes(strs, name, (int32_t)(1 + strlen(name)));
+    saa_wbytes(strs, name, 1 + strlen(name));
     strslen += 1 + strlen(name);
 
     sym = saa_wstruct(syms);


### PR DESCRIPTION
Hello,
enabling compiler warning made it possible to identify many very dangerous type memsize truncations, perhaps these are remnants of the old 32bit code, since most everything is already compiled for 64bit platforms.

memsize -> 32bit -> memsize