### PR TITLE
outelf: fix dangeours truncating memsize to 32bit

### DIFF
--- a/output/outelf.c
+++ b/output/outelf.c
@@ -794,7 +794,7 @@ static void elf_deflabel(char *name, int32_t segment, int64_t offset,
         return;                 /* it wasn't an important one */
     }
 
-    saa_wbytes(strs, name, (int32_t)(1 + strlen(name)));
+    saa_wbytes(strs, name, 1 + strlen(name));
     strslen += 1 + strlen(name);
 
     lastsym = sym = saa_wstruct(syms);


### PR DESCRIPTION
Parent PR: https://github.com/netwide-assembler/nasm/pull/274