### PR TITLE
assemble: fix truncation 32bit bitwise shift

### DIFF
--- a/asm/assemble.c
+++ b/asm/assemble.c
@@ -3205,7 +3205,7 @@ static enum match_result matches(const struct itemplate * const itemp,
 
     nasm_static_assert(SIZE_SHIFT >= IF_SB);
     nasm_static_assert((BITS8 >> SIZE_SHIFT) == 1);
-    arsize = (arflag & IF_TSMASK) << (SIZE_SHIFT - IF_SB);
+    arsize = (opflags_t)(arflag & IF_TSMASK) << (SIZE_SHIFT - IF_SB);
 
     if (arflag & IFM_OSIZE)
         arsize = opsize;


### PR DESCRIPTION
If the left shift pushes any bits beyond the 32nd bit, those bits will overflow and be permanently lost before the value gets expanded into the wider opflags_t space