### PR TITLE
disasm: fix truncation 32bit left bitwise shift

### DIFF
--- a/disasm/disasm.c
+++ b/disasm/disasm.c
@@ -328,7 +328,7 @@ static const uint8_t *do_ea(const uint8_t *data, int modrm,
             break;
         case 1:
             op->segment |= SEG_DISP8;
-            op->offset = gets8(data) << get_disp8_shift(ins);
+            op->offset = (int64_t)gets8(data) << get_disp8_shift(ins);
             op->disp_size = 8;
             data++;
             break;
@@ -410,7 +410,7 @@ static const uint8_t *do_ea(const uint8_t *data, int modrm,
         case 1:
             op->segment |= SEG_DISP8;
             op->disp_size = 8;
-            op->offset = gets8(data) << get_disp8_shift(ins);
+            op->offset = (int64_t)gets8(data) << get_disp8_shift(ins);
             data++;
             break;
         case 2:


### PR DESCRIPTION
Even though shifting an 8-bit displacement usually won't exceed a 32-bit boundary, static analyzer flags it because a negative value (which has its sign bit extended into the 32-bit space) shifted left and then promoted to 64 bits can result in improper sign-extension or unintended data truncation at the 32-bit boundary