### PR TITLE
sync: fix memleak if realloc() unverified failed (OOM)

### DIFF
--- a/disasm/sync.c
+++ b/disasm/sync.c
@@ -48,11 +48,19 @@ void add_sync(uint64_t pos, uint64_t length)
     if (nsynx >= max_synx) {
         struct Sync *xsynx;
         size_t xmaxsynx = max_synx << 1;
-        if (synx_oom || xmaxsynx < max_synx ||
-            !(xsynx = realloc(synx, (xmaxsynx + 1) * sizeof(*synx)))) {
+        if (synx_oom || xmaxsynx < max_synx) {
             synx_oom = true;
             return;
         }
+
+        xsynx = realloc(synx, (xmaxsynx + 1) * sizeof(*synx));
+        if (!xsynx) {
+            synx_oom = true;
+            return;
+        }
+
+        synx = xsynx;
+        max_synx = xmaxsynx;
     }
 
     nsynx++;


### PR DESCRIPTION
realloc() always need check on valid ptr maybe out of memory

References:
- https://stackoverflow.com/questions/21006707/proper-usage-of-realloc
- https://stackoverflow.com/questions/1986538/how-to-handle-realloc-when-it-fails-due-to-memory