### PR TITLE
outaout: add aout2 driver

### DIFF
--- a/doc/outfmt.src
+++ b/doc/outfmt.src
@@ -1535,6 +1535,21 @@ directive as \c{elf} does: see \k{elfglob} for documentation of
 this.
 
 
+\H{aout2fmt} \i\c{aout2}: \i{OS/2}
+\I{a.out, OS/2 version}\c{a.out} Object Files
+
+The \c{aout2} output format is the same as \c{aout}. In addition,
+
+\c{aout2} provides \c{EXPORT} to export DLL symbols like \c{obj}. See \k{export}.
+However, \c{aout2} supports \e{external} name and \e{ordinal} only.
+
+For example:
+
+\c     export  myfunc
+\c     export  myfunc TheRealMoreFormalLookingFunctionName
+\c     export  myfunc myfunc 1234  ; export by ordinal
+
+
 \H{as86fmt} \c{as86}: \i{Minix}/Linux\I{linux, as86} \i\c{as86} Object Files
 
 The Minix/Linux 16-bit assembler \c{as86} has its own non-standard

--- a/output/outaout.c
+++ b/output/outaout.c
@@ -20,7 +20,7 @@
 #include "outform.h"
 #include "outlib.h"
 
-#if defined OF_AOUT || defined OF_AOUTB
+#if defined OF_AOUT || defined OF_AOUTB || defined OF_AOUT2
 
 #define RELTYPE_ABSOLUTE 0x00
 #define RELTYPE_RELATIVE 0x01
@@ -64,6 +64,7 @@ struct Symbol {
  * More flags used in Symbol.type.
  */
 #define SYM_GLOBAL 1            /* it's a global symbol */
+#define SYM_EXPORT 0x6C         /* it's an exported symbol on OS/2 */
 #define SYM_DATA 0x100          /* used for shared libs */
 #define SYM_FUNCTION 0x200      /* used for shared libs */
 #define SYM_WITH_SIZE 0x4000    /* not output; internal only */
@@ -283,7 +284,10 @@ static void aout_deflabel(char *name, int32_t segment, int64_t offset,
     sym = saa_wstruct(syms);
 
     sym->strpos = pos;
-    sym->type = is_global ? SYM_GLOBAL : 0;
+    if (is_global == 4)
+        sym->type = SYM_EXPORT;
+    else
+        sym->type = is_global ? SYM_GLOBAL : 0;
     sym->segment = segment;
     if (segment == NO_SEG)
         sym->type |= SECT_ABS;
@@ -310,7 +314,7 @@ static void aout_deflabel(char *name, int32_t segment, int64_t offset,
             sbss.asym = sym;
     } else
         sym->type = SYM_GLOBAL;
-    if (is_global == 2)
+    if (is_global == 2 || is_global == 4)
         sym->value = offset;
     else
         sym->value = (sym->type == SYM_GLOBAL ? 0 : offset);
@@ -838,9 +842,80 @@ static void aout_sect_write(struct Section *sect,
     sect->len += len;
 }
 
-extern macros_t aout_stdmac[];
+#ifdef OF_AOUT2
 
-#endif                          /* OF_AOUT || OF_AOUTB */
+static enum directive_result
+aout2_directive(enum directive directive, char *value)
+{
+    switch (directive) {
+    case D_EXPORT:
+        /* Is pass_first() really correct? */
+        if (value && pass_first()) {
+            char *q, *extname, *intname, *v;
+            unsigned int ordinal = 0;
+            bool err;
+            /* .stabs "<exportname>,<ordinal>=<asmname>,<code|data>", 0x6C,0,0,-42 */
+            char export[255 + 1 + 5 + 1 + 255 + 1 + 4 + 1];
+
+            intname = q = value;
+            while (*q && !nasm_isspace(*q))
+                q++;
+            if (nasm_isspace(*q)) {
+                *q++ = '\0';
+                while (*q && nasm_isspace(*q))
+                    q++;
+            }
+
+            extname = q;
+            while (*q && !nasm_isspace(*q))
+                q++;
+            if (nasm_isspace(*q)) {
+                *q++ = '\0';
+                while (*q && nasm_isspace(*q))
+                    q++;
+            }
+
+            if (!*intname) {
+                nasm_nonfatal("`export' directive requires export name");
+                return DIRR_ERROR;
+            }
+            if (!*extname)
+                extname = intname;
+            while (*q) {
+                v = q;
+                while (*q && !nasm_isspace(*q))
+                    q++;
+                if (nasm_isspace(*q)) {
+                    *q++ = '\0';
+                    while (*q && nasm_isspace(*q))
+                        q++;
+                }
+                err = false;
+                ordinal = readnum(v, &err);
+                if (err) {
+                    nasm_nonfatal("invalid ordinal `%s'", v);
+                    return DIRR_ERROR;
+                }
+            }
+            /* assume function */
+            snprintf(export, sizeof(export), "%s,%d=%s,%s",
+                     extname, ordinal, intname, "code");
+            aout_deflabel(export, stext.index, -42, 4, NULL);
+        }
+        return DIRR_OK;
+
+    default:
+        return DIRR_UNKNOWN;
+    }
+}
+
+#endif
+
+#if defined(OF_AOUT) || defined(OF_AOUTB)
+extern macros_t aout_stdmac[];
+#endif
+
+#endif                          /* OF_AOUT || OF_AOUTB || OF_AOUT2 */
 
 #ifdef OF_AOUT
 
@@ -888,6 +963,34 @@ const struct ofmt of_aoutb = {
     null_sectalign,
     null_segbase,
     null_directive,
+    aout_cleanup,
+    NULL                        /* pragma list */
+};
+
+#endif
+
+#ifdef OF_AOUT2
+
+extern macros_t aout2_stdmac[];
+
+const struct ofmt of_aout2 = {
+    "OS/2 a.out",
+    "aout2",
+    ".o",
+    0,
+    32,
+    null_debug_arr,
+    &null_debug_form,
+    aout2_stdmac,
+    aout_init,
+    null_reset,
+    aout_out,
+    aout_deflabel,
+    aout_section_names,
+    NULL,
+    null_sectalign,
+    null_segbase,
+    aout2_directive,
     aout_cleanup,
     NULL                        /* pragma list */
 };

--- a/output/outaout.mac
+++ b/output/outaout.mac
@@ -5,3 +5,11 @@ OUT: aout aoutb
 %define __?SECT?__ [section .text]
 %macro __?NASM_CDecl?__ 1
 %endmacro
+
+OUT: aout2
+%define __?SECT?__ [section .text]
+%macro __?NASM_CDecl?__ 1
+%endmacro
+%imacro export 1+.nolist
+[export %1]
+%endmacro

--- a/output/outform.h
+++ b/output/outform.h
@@ -16,7 +16,7 @@
  * OF_name                -- ensure that output format 'name' is included
  * OF_NO_name             -- remove output format 'name'
  * OF_DOS                 -- ensure that 'obj', 'obj2', 'bin', 'win32' & 'win64' are included.
- * OF_UNIX                -- ensure that 'aout', 'aoutb', 'coff', 'elf32' & 'elf64' are in.
+ * OF_UNIX                -- ensure that 'aout', 'aoutb', 'aout2', 'coff', 'elf32' & 'elf64' are in.
  * OF_OTHERS              -- ensure that 'bin', 'as86', 'rdf' 'macho32' & 'macho64' are in.
  * OF_ALL                 -- ensure that all formats are included.
  *                           note that this doesn't include 'dbg', which is
@@ -56,7 +56,7 @@
 
 /* ====configurable info begins here==== */
 /* formats configurable:
- * bin,obj,obj2,elf32,elf64,aout,aoutb,coff,win32,as86,rdf2,macho32,macho64 */
+ * bin,obj,obj2,elf32,elf64,aout,aoutb,aout2coff,win32,as86,rdf2,macho32,macho64 */
 
 /* process options... */
 
@@ -93,6 +93,9 @@
 #endif
 #ifndef OF_AOUTB
 #define OF_AOUTB
+#endif
+#ifndef OF_AOUT2
+#define OF_AOUT2
 #endif
 #ifndef OF_WIN32
 #define OF_WIN32
@@ -145,6 +148,9 @@
 #endif
 #ifndef OF_AOUTB
 #define OF_AOUTB
+#endif
+#ifndef OF_AOUT2
+#define OF_AOUT2
 #endif
 #ifndef OF_COFF
 #define OF_COFF
@@ -203,6 +209,9 @@
 #ifdef OF_NO_AOUTB
 #undef OF_AOUTB
 #endif
+#ifdef OF_NO_AOUT2
+#undef OF_AOUT2
+#endif
 #ifdef OF_NO_COFF
 #undef OF_COFF
 #endif
@@ -237,6 +246,7 @@ extern const struct ofmt of_ith;
 extern const struct ofmt of_srec;
 extern const struct ofmt of_aout;
 extern const struct ofmt of_aoutb;
+extern const struct ofmt of_aout2;
 extern const struct ofmt of_coff;
 extern const struct ofmt of_elf32;
 extern const struct ofmt of_elfx32;
@@ -269,6 +279,9 @@ static const struct ofmt * const drivers[] = {
 #endif
 #ifdef OF_AOUTB
     &of_aoutb,
+#endif
+#ifdef OF_AOUT2
+    &of_aout2,
 #endif
 #ifdef OF_COFF
     &of_coff,


### PR DESCRIPTION
Aout2 is an aout variation for OS/2. Aout2 supports to export symbols.