### PR TITLE
Add RDPRU instruction

### DIFF
--- a/x86/iflags.ph
+++ b/x86/iflags.ph
@@ -186,7 +186,7 @@ if_("AVX10_2",           "AVX 10.2 instructions");
 if_("AVX10_VNNIINT",     "AVX Vector Neural Network integer instructions");
 if_("ADX",               "ADCX and ADOX instructions");
 if_("PKU",		 "Protection key for user mode");
-if_("RDPKU",             "RDPRU instruction");
+if_("RDPRU",             "RDPRU instruction");
 if_("MONITOR",		 "MONITOR and MWAIT");
 if_("MONITORX",		 "MONITORX and MWAITX");
 if_("WAITPKG",           "User wait instruction package");

--- a/x86/iflags.ph
+++ b/x86/iflags.ph
@@ -186,6 +186,7 @@ if_("AVX10_2",           "AVX 10.2 instructions");
 if_("AVX10_VNNIINT",     "AVX Vector Neural Network integer instructions");
 if_("ADX",               "ADCX and ADOX instructions");
 if_("PKU",		 "Protection key for user mode");
+if_("RDPKU",             "RDPRU instruction");
 if_("MONITOR",		 "MONITOR and MWAIT");
 if_("MONITORX",		 "MONITORX and MWAITX");
 if_("WAITPKG",           "User wait instruction package");

--- a/x86/insns.dat
+++ b/x86/insns.dat
@@ -1,4 +1,4 @@
-W;; SPDX-License-Identifier: BSD-2-Clause
+;; SPDX-License-Identifier: BSD-2-Clause
 ;; Copyright 1996-2026 The NASM Authors - All Rights Reserved
 
 ;

--- a/x86/insns.dat
+++ b/x86/insns.dat
@@ -5187,6 +5187,7 @@ VXORPS          zmmreg|mask|z,zmmreg*,zmmrm512|b32  [rvm:fv: evex.nds.512.0f.w0 
 ;# Intel memory protection keys for userspace (PKU aka PKEYs)
 RDPKRU		void				[	0f 01 ee]				PKU,LONG
 WRPKRU		void				[	0f 01 ef]				PKU,LONG
+RDPRU           void                            [       0f 01 fd]                               RDPKU
 
 ;# Read Processor ID
 

--- a/x86/insns.dat
+++ b/x86/insns.dat
@@ -1,4 +1,4 @@
-;; SPDX-License-Identifier: BSD-2-Clause
+W;; SPDX-License-Identifier: BSD-2-Clause
 ;; Copyright 1996-2026 The NASM Authors - All Rights Reserved
 
 ;
@@ -5187,7 +5187,7 @@ VXORPS          zmmreg|mask|z,zmmreg*,zmmrm512|b32  [rvm:fv: evex.nds.512.0f.w0 
 ;# Intel memory protection keys for userspace (PKU aka PKEYs)
 RDPKRU		void				[	0f 01 ee]				PKU,LONG
 WRPKRU		void				[	0f 01 ef]				PKU,LONG
-RDPRU           void                            [       0f 01 fd]                               RDPKU
+RDPRU           void                            [       0f 01 fd]                               RDPRU
 
 ;# Read Processor ID
 


### PR DESCRIPTION
Add support for the AMD RDPRU instruction (0F 01 FD).

This adds the RDPKU instruction flag and the corresponding
RDPRU encoding to x86/insns.dat.