### PR TITLE
pragma: fix NULL-pointer dereference on malformed --pragma input

### DIFF
--- a/asm/pragma.c
+++ b/asm/pragma.c
@@ -222,6 +222,15 @@ void process_pragma(char *str)
      * interior spaces.
      */
     p = nasm_zap_spaces_fwd(p);
+    if (p == NULL) {
+        /* Missing opname and/or options; avoid a NULL-pointer
+         * dereference in strlen() below.  Report it explicitly
+         * instead of crashing. */
+        nasm_error(ERR_NONFATAL, "bad argument to %%pragma %s: missing opname",
+                   pragma.facility_name ? pragma.facility_name : "");
+        pragma.tail = NULL;
+        return;
+    }
     pragma.tail = p;
     p += strlen(p);
     while (p > pragma.tail && nasm_isspace(p[-1]))


### PR DESCRIPTION
Fixes: #300

    When --pragma is given with a facility but no opname (e.g.
    `nasm --pragma 'str' file.asm`), nasm_get_word() returns NULL and sets the
    tail pointer to NULL.  process_pragma() then calls strlen() on the NULL
    tail, causing a segmentation fault (NULL dereference).

    Avoid the NULL dereference and report the malformed input explicitly:

        nasm --pragma 'str' t.asm
        t.asm: error: bad argument to %pragma str: missing opname

    Verified: patch applies cleanly on master, full `./configure && make`
    build succeeds (exit 0).