### PR TITLE
disasm/sync.c: fix lost realloc (use after free)

### DIFF
--- a/disasm/sync.c
+++ b/disasm/sync.c
@@ -53,6 +53,8 @@ void add_sync(uint64_t pos, uint64_t length)
             synx_oom = true;
             return;
         }
+        synx = xsynx;
+        max_synx = xmaxsynx;
     }
 
     nsynx++;


### PR DESCRIPTION
The new length and the result of realloc() are stored in temporary variables, but never propagated to the global state.