### PR TITLE
Remove mistyped entries

### DIFF
--- a/x86/insns.dat
+++ b/x86/insns.dat
@@ -5664,10 +5664,6 @@ VREDUCEPH	xmmreg|mask|z,xmmrm128|b16,imm8		[rmi:fv: evex.128.np.0f3a.w0 56 /r ib
 VREDUCEPH	ymmreg|mask|z,ymmrm256|b16,imm8		[rmi:fv: evex.256.np.0f3a.w0 56 /r ib]	AVX512FP16,AVX512VL
 VREDUCEPH	zmmreg|mask|z,zmmrm512|b16|sae,imm8	[rmi:fv: evex.512.np.0f3a.w0 56 /r ib]	AVX512FP16
 VREDUCESH	xmmreg|mask|z,xmmreg*,xmmrm16|sae,imm8	[rvmi:t1s: evex.nds.lig.np.0f3a.w0 57 /r ib]	AVX512FP16
-VENDSCALEPH	xmmreg|mask|z,xmmrm128|b16,imm8		[rmi:fv: evex.128.np.0f3a.w0 08 /r ib]	AVX512FP16,AVX512VL
-VENDSCALEPH	ymmreg|mask|z,ymmrm256|b16,imm8		[rmi:fv: evex.256.np.0f3a.w0 08 /r ib]	AVX512FP16,AVX512VL
-VENDSCALEPH	zmmreg|mask|z,zmmrm512|b16|sae,imm8	[rmi:fv: evex.512.np.0f3a.w0 08 /r ib]	AVX512FP16
-VENDSCALESH	xmmreg|mask|z,xmmreg*,xmmrm16|sae,imm8	[rvmi:t1s: evex.nds.lig.np.0f3a.w0 0a /r ib]	AVX512FP16
 VRSQRTPH	xmmreg|mask|z,xmmrm128|b16		[rm:fv: evex.128.66.map6.w0 4e /r]	AVX512FP16,AVX512VL
 VRSQRTPH	ymmreg|mask|z,ymmrm256|b16		[rm:fv: evex.256.66.map6.w0 4e /r]	AVX512FP16,AVX512VL
 VRSQRTPH	zmmreg|mask|z,zmmrm512|b16|sae		[rm:fv: evex.512.66.map6.w0 4e /r]	AVX512FP16


### PR DESCRIPTION
Hi guys, I hope I am not misunderstanding this, but seems to me like those four instructions:

VRNDSCALEPH     xmmreg|mask|z,xmmrm128|b16,imm8     [rmi:fv: evex.128.np.0f3a.w0 08 /r ib ] AVX512VL,AVX512FP16
VRNDSCALEPH     ymmreg|mask|z,ymmrm256|b16,imm8     [rmi:fv: evex.256.np.0f3a.w0 08 /r ib ] AVX512VL,AVX512FP16
VRNDSCALEPH     zmmreg|mask|z,zmmrm512|b16|sae,imm8 [rmi:fv: evex.512.np.0f3a.w0 08 /r ib ] AVX512FP16

VRNDSCALESH     xmmreg|mask|z,xmmreg*,xmmrm16|sae,imm8 [rvmi:t1s: evex.nds.lig.np.0f3a.w0 0a /r ib ] AVX512FP16

are mistyped and repeated under VENDSCALEPH and VENDSCALESH entries.

I have looked in SDM Vol 2 which contains all instruction references but I can't find anything named VENDSCALE* (I am using text extracted version I can grep over). The same for the ISA extensions and future sets. I did a web search for those two to check if they are part of some AMD extension, but we search returns nothing, and neither Gemini nor DS can find any reference to those two instructions either. I use both yours x86 instructions table, and also llvm-tblgen to extract avx512 instructions and cross reference to generate instructions for sbcl backend, so these are in yours list but not in llvm, so I had to check them up.

I hope I am not wrong, if I am, sorry for the noise.
best regards